### PR TITLE
Kubernetes configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,4 @@ Dockerfile
 .gitignore
 .github
 .husky
-client
 docker

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ test-results
 
 # ESlint
 .eslintcache
+
+# Emskaffolden
+*.compiled.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:18.17.1-alpine3.17
+ARG FRONTEND_ENV=dev
 
 # Install init process tool to avoid Node running PID 1
 RUN apk --no-cache add dumb-init=1.2.5-r2
@@ -10,7 +11,10 @@ WORKDIR /usr/src/app
 COPY --chown=node:node . .
 
 # Install dependencies
-RUN yarn workspaces focus --all --production
+RUN yarn workspaces focus --all
+
+# Build frontend
+RUN yarn build-front:${FRONTEND_ENV}
 
 # App binds to port 5000
 EXPOSE 5000

--- a/client/config/kube-dev.env
+++ b/client/config/kube-dev.env
@@ -1,0 +1,4 @@
+SETTINGS=development
+API_SERVER_URL=http://konsti.localhost
+SHOW_TEST_VALUES=true
+DATA_UPDATE_INTERVAL=60

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build:ci": "yarn clean && webpack-cli",
     "build:dev": "yarn clean && webpack-cli",
+    "build:kube-dev": "yarn clean && webpack-cli",
     "build:prod": "yarn clean && webpack-cli",
     "build:staging": "yarn clean && webpack-cli",
     "bundle-analyzer": "webpack-cli --profile --json > stats.json && webpack-bundle-analyzer stats.json build -m server",

--- a/client/webpack.config.ts
+++ b/client/webpack.config.ts
@@ -19,6 +19,8 @@ const getEnvVariableFile = (): string | undefined => {
       return "./config/staging.env";
     case "build:ci":
       return "./config/ci.env";
+    case "build:kube-dev":
+      return "./config/kube-dev.env";
     default:
       return "./config/dev.env";
   }
@@ -171,6 +173,8 @@ const getWebpackConfig = (): Configuration | undefined => {
     case "build:staging":
       return merge(commonConfig, prodConfig);
     case "build:dev":
+      return merge(commonConfig, prodConfig);
+    case "build:kube-dev":
       return merge(commonConfig, prodConfig);
     case "build:ci":
       return merge(commonConfig, prodConfig);

--- a/kubernetes/.gitignore
+++ b/kubernetes/.gitignore
@@ -1,0 +1,2 @@
+# may contain secrets
+*.local.yaml

--- a/kubernetes/default.vars.yaml
+++ b/kubernetes/default.vars.yaml
@@ -1,0 +1,99 @@
+# Note: If you use Skaffold/Emskaffolden, leave these at defaults and let Skaffold manage the images
+konsti_image: konsti
+
+# Set to false to manage a secret called "konsti" yourself
+konsti_secret_managed: true
+
+# Which ENV of yarn build-front:ENV to use
+konsti_frontend_env: kube-dev
+
+# Set this to the public hostname of your service.
+ingress_public_hostname: konsti.localhost
+
+# If you use ingress-nginx and cert-manager, TLS can be automatically configured by setting this to true.
+ingress_letsencrypt_enabled: false
+ingress_letsencrypt_cluster_issuer: letsencrypt-prod
+
+mongodb_managed: true
+mongodb_image: mongo:6.0.8-jammy
+mongodb_connection_string: mongodb://mongodb:27017/konsti
+
+smtp_hostname: ""
+smtp_port: 25
+smtp_from_email: nonexistent@example.com
+smtp_username: ""
+
+# konsti_secret_managed: false - ignored
+# konsti_secret_managed: true - set to this value in secret, or leave empty to have auto-generated via kubernetes-secret-generator
+smtp_password: ""
+
+# Configuration vars end here. Configuration snippets follow. May be overridden for advanced configuration.
+
+# Security context for konsti and Celery pods
+konsti_pod_security_context:
+  runAsUser: 1000
+  runAsGroup: 1000
+konsti_container_security_context:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+
+# Common environment vars for both konsti and celery pods.
+konsti_environment:
+  - name: NODE_ENV
+    value: production
+  - name: CONN_STRING
+    value: !Var mongodb_connection_string
+  - name: CORS_WHITELIST
+    value: !Var ingress_url
+  - name: SMTP_HOST
+    value: !Var smtp_hostname
+  - name: SMTP_PORT
+    value: !Format "{smtp_port}"
+  - name: SMTP_FROM_EMAIL
+    value: !Var smtp_from_email
+  - !If
+      test: !Var smtp_username
+      then:
+        name: SMTP_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: konsti
+            key: smtpUsername
+  - !If
+      test: !Var smtp_username
+      then:
+        name: SMTP_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: konsti
+            key: smtpPassword
+
+# Default annotations work for nginx ingress with or without LetsEncrypt TLS. Override if you need something else.
+ingress_annotations: !If
+  test: !Var ingress_letsencrypt_enabled
+  then:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    kubernetes.io/ingress.class: "nginx"
+  else:
+    kubernetes.io/ingress.class: "nginx"
+
+ingress_tls: !If
+  test: !Var ingress_letsencrypt_enabled
+  then:
+    - secretName: ingress-letsencrypt
+      hosts:
+        - !Var ingress_public_hostname
+
+ingress_url: !If
+  test: !Var ingress_letsencrypt_enabled
+  then: !Format "https://{ingress_public_hostname}"
+  else: !Format "http://{ingress_public_hostname}"
+
+konsti_volume_mounts:
+  - mountPath: /tmp
+    name: konsti-temp
+
+konsti_volumes:
+  - name: konsti-temp
+    emptyDir: {}

--- a/kubernetes/development.vars.yaml
+++ b/kubernetes/development.vars.yaml
@@ -1,0 +1,7 @@
+postgres_password: konsti
+konsti_secret_key: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+konsti_utils_secret_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+smtp_password: secret
+ingress_letsencrypt_enabled: false
+konsti_insecure_local_auth_enabled: true
+konsti_frontend_env: kube-dev

--- a/kubernetes/ingress.in.yaml
+++ b/kubernetes/ingress.in.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: konsti
+  annotations: !Var ingress_annotations
+spec:
+  tls: !Var ingress_tls
+  rules:
+    - host: !Var ingress_public_hostname
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: konsti
+                port:
+                  number: 5000

--- a/kubernetes/konsti/cron-deployment.in.yaml
+++ b/kubernetes/konsti/cron-deployment.in.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cron
+  labels:
+    app.kubernetes.io/part-of: konsti
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: cron
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: konsti
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: cron
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: konsti
+        app.kubernetes.io/component: server
+        app.kubernetes.io/name: cron
+    spec:
+      enableServiceLinks: false
+      securityContext: !Var konsti_pod_security_context
+      containers:
+        - name: konsti
+          image: !Var konsti_image
+          env: !Concat
+            - !Var konsti_environment
+            - - name: ONLY_CRONJOBS
+                value: 'true'
+          securityContext: !Var konsti_container_security_context
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 5000
+              httpHeaders:
+                - name: Host
+                  value: !Var ingress_public_hostname
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 5000
+              httpHeaders:
+                - name: Host
+                  value: !Var ingress_public_hostname
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts: !Var konsti_volume_mounts
+      volumes: !Var konsti_volumes

--- a/kubernetes/konsti/konsti-deployment.in.yaml
+++ b/kubernetes/konsti/konsti-deployment.in.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: konsti
+  labels:
+    app.kubernetes.io/part-of: konsti
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: konsti
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: konsti
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: konsti
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: konsti
+        app.kubernetes.io/component: server
+        app.kubernetes.io/name: konsti
+    spec:
+      enableServiceLinks: false
+      securityContext: !Var konsti_pod_security_context
+      containers:
+        - name: konsti
+          image: !Var konsti_image
+          ports:
+            - containerPort: 5000
+          env: !Var konsti_environment
+          securityContext: !Var konsti_container_security_context
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 5000
+              httpHeaders:
+                - name: Host
+                  value: !Var ingress_public_hostname
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 5000
+              httpHeaders:
+                - name: Host
+                  value: !Var ingress_public_hostname
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts: !Var konsti_volume_mounts
+      volumes: !Var konsti_volumes

--- a/kubernetes/konsti/secret.in.yaml
+++ b/kubernetes/konsti/secret.in.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: konsti
+  labels:
+    app.kubernetes.io/part-of: konsti
+type: Opaque
+data: {}

--- a/kubernetes/konsti/service.in.yaml
+++ b/kubernetes/konsti/service.in.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: konsti
+  labels:
+    app.kubernetes.io/part-of: konsti
+    app.kubernetes.io/name: konsti
+spec:
+  ports:
+  - port: 5000
+    targetPort: 5000
+  selector:
+    app.kubernetes.io/part-of: konsti
+    app.kubernetes.io/name: konsti

--- a/kubernetes/mongodb/service.in.yaml
+++ b/kubernetes/mongodb/service.in.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app.kubernetes.io/part-of: konsti
+    app.kubernetes.io/component: database
+    app.kubernetes.io/name: mongodb
+spec:
+  ports:
+    - port: 27017
+      targetPort: 27017
+  selector:
+    app.kubernetes.io/part-of: konsti
+    app.kubernetes.io/component: database
+    app.kubernetes.io/name: mongodb

--- a/kubernetes/mongodb/statefulset.in.yaml
+++ b/kubernetes/mongodb/statefulset.in.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb
+  labels:
+    app.kubernetes.io/part-of: konsti
+    app.kubernetes.io/component: database
+    app.kubernetes.io/name: mongodb
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: konsti
+      app.kubernetes.io/component: database
+      app.kubernetes.io/name: mongodb
+  serviceName: mongodb
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: konsti
+        app.kubernetes.io/component: database
+        app.kubernetes.io/name: mongodb
+    spec:
+      enableServiceLinks: false
+      containers:
+        - name: mongodb
+          image: !Var mongodb_image
+          ports:
+            - containerPort: 27017
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi

--- a/kubernetes/production.vars.yaml
+++ b/kubernetes/production.vars.yaml
@@ -1,0 +1,14 @@
+ingress_public_hostname: konsti.con2.fi
+
+konsti_secret_managed: false
+konsti_frontend_env: prod
+
+ingress_letsencrypt_enabled: true
+ingress_letsencrypt_cluster_issuer: letsencrypt-prod
+
+smtp_hostname: sr1.pahaip.fi
+smtp_from_email: root@tracon.fi
+
+kompassi_admin_groups:
+  - konsti-staff
+  - admins

--- a/kubernetes/staging.vars.yaml
+++ b/kubernetes/staging.vars.yaml
@@ -1,0 +1,13 @@
+ingress_public_hostname: dev.konsti.con2.fi
+
+konsti_secret_managed: false
+
+ingress_letsencrypt_enabled: true
+ingress_letsencrypt_cluster_issuer: letsencrypt-prod
+
+smtp_hostname: sr1.pahaip.fi
+smtp_from_email: root@tracon.fi
+
+kompassi_admin_groups:
+  - konsti-staff
+  - admins

--- a/kubernetes/template.in.yaml
+++ b/kubernetes/template.in.yaml
@@ -1,0 +1,38 @@
+# konsti deployment using Kubernetes
+# usage: emrichen -f default.vars.yaml kubernetes.in.yaml | kubectl apply -n konsti -f -
+
+
+###########
+# MONGODB #
+###########
+---
+!If
+  test: !Var mongodb_managed
+  then: !Include mongodb/service.in.yaml
+
+---
+!If
+  test: !Var mongodb_managed
+  then: !Include mongodb/statefulset.in.yaml
+
+
+###############
+# APPLICATION #
+###############
+---
+!Include konsti/service.in.yaml
+---
+!Include konsti/cron-deployment.in.yaml
+---
+!Include konsti/konsti-deployment.in.yaml
+---
+!If
+  test: !Var konsti_secret_managed
+  then: !Include konsti/secret.in.yaml
+
+
+###########
+# INGRESS #
+###########
+---
+!Include ingress.in.yaml

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build-front:ci": "yarn workspace konsti-client build:ci && yarn copy-front",
     "build-front:dev": "yarn workspace konsti-client build:dev && yarn copy-front",
+    "build-front:kube-dev": "yarn workspace konsti-client build:kube-dev && yarn copy-front",
     "build-front:prod": "yarn workspace konsti-client build:prod && yarn copy-front",
     "build-front:staging": "yarn workspace konsti-client build:staging && yarn copy-front",
     "build-server": "yarn workspace konsti-server build",

--- a/skaffold.in.yaml
+++ b/skaffold.in.yaml
@@ -1,0 +1,21 @@
+apiVersion: skaffold/v2beta9
+kind: Config
+metadata:
+  name: outline
+
+build:
+  local:
+    useBuildkit: true
+  artifacts:
+    - image: konsti
+      context: .
+      docker:
+        dockerfile: Dockerfile
+        buildArgs:
+          FRONTEND_ENV: !Var konsti_frontend_env
+
+deploy:
+  statusCheckDeadlineSeconds: 300
+  kubectl:
+    manifests:
+      - kubernetes/template.compiled.yaml


### PR DESCRIPTION
- [x] @Archinowsk Optimize Docker build times and image sizes using multistage build
- [ ] CI/CD
  - [ ] Which runners to use? If Con2 organization runners, need to move repo to con2 org. Can also set up organization runners for Ropekonsti org.
  - [ ] @japsu actions-runner-controller in Qb kubernetes is aeons old. Upgrade to current version
- [ ] @Archinowsk Check environment variables

Together in another session:

- [ ] How to use secrets
- [ ] MongoDB in production: Use Atlas or set up backups etc in local MongoDB
- [ ] Use ropekonsti.fi domain in production, test.ropekonsti.fi in staging
