### PR TITLE
Start single mongodb-memory-server before all tests

### DIFF
--- a/server/src/features/feedback/feedbackController.test.ts
+++ b/server/src/features/feedback/feedbackController.test.ts
@@ -1,14 +1,6 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { startServer, closeServer } from "server/utils/server";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
@@ -16,15 +8,10 @@ import { getJWT } from "server/utils/jwt";
 import { UserGroup } from "shared/typings/models/user";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -32,10 +19,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test(`POST ${ApiEndpoint.FEEDBACK} should return 401 without valid authorization`, async () => {

--- a/server/src/features/feedback/feedbackRepository.test.ts
+++ b/server/src/features/feedback/feedbackRepository.test.ts
@@ -1,35 +1,17 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { FeedbackModel } from "server/features/feedback/feedbackSchema";
 import { saveFeedback } from "server/features/feedback/feedbackRepository";
 
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("should insert new feedback into collection", async () => {

--- a/server/src/features/game-popularity/updateGamePopularity.test.ts
+++ b/server/src/features/game-popularity/updateGamePopularity.test.ts
@@ -1,14 +1,5 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  vi,
-} from "vitest";
-import { MongoMemoryServer } from "mongodb-memory-server";
+import { expect, test, afterEach, beforeEach, vi } from "vitest";
 import { faker } from "@faker-js/faker";
 import dayjs from "dayjs";
 import { startServer, closeServer } from "server/utils/server";
@@ -21,15 +12,10 @@ import { updateGamePopularity } from "server/features/game-popularity/updateGame
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -37,10 +23,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test(`Should update game popularity`, async () => {

--- a/server/src/features/game/gameController.test.ts
+++ b/server/src/features/game/gameController.test.ts
@@ -1,19 +1,9 @@
 import { Server } from "http";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import dayjs from "dayjs";
 import _ from "lodash";
-import {
-  expect,
-  test,
-  vi,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-} from "vitest";
+import { expect, test, vi, afterEach, beforeEach, describe } from "vitest";
 import { startServer, closeServer } from "server/utils/server";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { getJWT } from "server/utils/jwt";
@@ -60,15 +50,10 @@ import {
 } from "server/test/mock-data/mockKompassiGameHitpoint";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -76,10 +61,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`GET ${ApiEndpoint.GAMES}`, () => {

--- a/server/src/features/game/gameRepository.test.ts
+++ b/server/src/features/game/gameRepository.test.ts
@@ -1,13 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { GameModel } from "server/features/game/gameSchema";
 import { saveGames } from "server/features/game/gameRepository";
@@ -16,24 +8,14 @@ import { removeDeletedGames } from "server/features/game/gameUtils";
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 import { findSignups } from "server/features/signup/signupRepository";
 
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("should insert new game into collection", async () => {

--- a/server/src/features/health/healthController.test.ts
+++ b/server/src/features/health/healthController.test.ts
@@ -1,29 +1,15 @@
 import { Server } from "http";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-} from "vitest";
+import { expect, test, afterEach, beforeEach, describe } from "vitest";
 import { startServer, closeServer } from "server/utils/server";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -31,10 +17,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`GET ${ApiEndpoint.HEALTH}`, () => {

--- a/server/src/features/kompassiLogin/kompassiLoginController.test.ts
+++ b/server/src/features/kompassiLogin/kompassiLoginController.test.ts
@@ -1,15 +1,6 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, describe, beforeEach } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { closeServer, startServer } from "server/utils/server";
@@ -21,15 +12,10 @@ import { mockUser, mockUser2 } from "server/test/mock-data/mockUser";
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -37,10 +23,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`POST ${ApiEndpoint.VERIFY_KOMPASSI_LOGIN}`, () => {

--- a/server/src/features/player-assignment/assignmentController.test.ts
+++ b/server/src/features/player-assignment/assignmentController.test.ts
@@ -1,28 +1,15 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { startServer, closeServer } from "server/utils/server";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -30,10 +17,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test(`POST ${ApiEndpoint.ASSIGNMENT} should return 401 without valid authorization`, async () => {

--- a/server/src/features/player-assignment/runAssignment.test.ts
+++ b/server/src/features/player-assignment/runAssignment.test.ts
@@ -1,14 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-} from "vitest";
+import { expect, test, afterEach, beforeEach, describe } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import dayjs from "dayjs";
 import { faker } from "@faker-js/faker";
 import { runAssignment } from "server/features/player-assignment/runAssignment";
@@ -37,28 +28,18 @@ import { assertUserUpdatedCorrectly } from "server/features/player-assignment/ru
 import { DIRECT_SIGNUP_PRIORITY } from "shared/constants/signups";
 import { GameModel } from "server/features/game/gameSchema";
 
-let mongoServer: MongoMemoryServer;
-
 // This needs to be adjusted if test data is changed
 const expectedResultsCount = 18;
 const groupTestUsers = ["group1", "group2", "group3"];
 
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe("Assignment with valid data", () => {

--- a/server/src/features/player-assignment/runAssignmentGroup.test.ts
+++ b/server/src/features/player-assignment/runAssignmentGroup.test.ts
@@ -1,13 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import dayjs from "dayjs";
 import { faker } from "@faker-js/faker";
 import { assertUserUpdatedCorrectly } from "server/features/player-assignment/runAssignmentTestUtils";
@@ -18,28 +10,18 @@ import { config } from "shared/config";
 import { AssignmentResultStatus } from "server/typings/result.typings";
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 
-let mongoServer: MongoMemoryServer;
-
 // This needs to be adjusted if test data is changed
 const expectedResultsCount = 12;
 const groupTestUsers = ["group1", "group2", "group3"];
 
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("Assignment with valid data should return success with group strategy", async () => {

--- a/server/src/features/player-assignment/runAssignmentGroupPadg.test.ts
+++ b/server/src/features/player-assignment/runAssignmentGroupPadg.test.ts
@@ -1,14 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  vi,
-} from "vitest";
+import { expect, test, afterEach, beforeEach, vi } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import dayjs from "dayjs";
 import { faker } from "@faker-js/faker";
 import { assertUserUpdatedCorrectly } from "server/features/player-assignment/runAssignmentTestUtils";
@@ -23,30 +14,20 @@ import * as padgAssign from "server/features/player-assignment/padg/padgAssignPl
 import { AssignmentError } from "shared/typings/api/errors";
 import { makeErrorResult } from "shared/utils/result";
 
-let mongoServer: MongoMemoryServer;
-
 // This needs to be adjusted if test data is changed
 const expectedResultsCount = 20;
 const groupTestUsers = ["group1", "group2", "group3"];
 
 const { conventionStartTime } = config.shared();
 
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("Assignment with valid data should return success with group+padg strategy", async () => {

--- a/server/src/features/player-assignment/runAssignmentPadg.test.ts
+++ b/server/src/features/player-assignment/runAssignmentPadg.test.ts
@@ -1,13 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import dayjs from "dayjs";
 import { faker } from "@faker-js/faker";
 import { assertUserUpdatedCorrectly } from "server/features/player-assignment/runAssignmentTestUtils";
@@ -34,28 +26,18 @@ import {
   saveSignup,
 } from "server/features/signup/signupRepository";
 
-let mongoServer: MongoMemoryServer;
-
 // This needs to be adjusted if test data is changed
 const expectedResultsCount = 20;
 const groupTestUsers = ["group1", "group2", "group3"];
 
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("Assignment with valid data should return success with padg strategy", async () => {

--- a/server/src/features/player-assignment/runAssignmentRandom.test.ts
+++ b/server/src/features/player-assignment/runAssignmentRandom.test.ts
@@ -1,13 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import dayjs from "dayjs";
 import { faker } from "@faker-js/faker";
 import { assertUserUpdatedCorrectly } from "server/features/player-assignment/runAssignmentTestUtils";
@@ -34,28 +26,18 @@ import {
 } from "server/features/signup/signupRepository";
 import { saveSignedGames } from "server/features/user/signed-game/signedGameRepository";
 
-let mongoServer: MongoMemoryServer;
-
 // This needs to be adjusted if test data is changed
 const expectedResultsCount = 20;
 const groupTestUsers = ["group1", "group2", "group3"];
 
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("Assignment with valid data should return success with random strategy", async () => {

--- a/server/src/features/player-assignment/runAssignmentRandomPadg.test.ts
+++ b/server/src/features/player-assignment/runAssignmentRandomPadg.test.ts
@@ -1,14 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  vi,
-} from "vitest";
+import { expect, test, afterEach, beforeEach, vi } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import dayjs from "dayjs";
 import { faker } from "@faker-js/faker";
 import { assertUserUpdatedCorrectly } from "server/features/player-assignment/runAssignmentTestUtils";
@@ -23,30 +14,20 @@ import * as padgAssign from "server/features/player-assignment/padg/padgAssignPl
 import { AssignmentError } from "shared/typings/api/errors";
 import { makeErrorResult } from "shared/utils/result";
 
-let mongoServer: MongoMemoryServer;
-
 // This needs to be adjusted if test data is changed
 const expectedResultsCount = 20;
 const groupTestUsers = ["group1", "group2", "group3"];
 
 const { conventionStartTime } = config.shared();
 
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("Assignment with valid data should return success with random+padg strategy", async () => {

--- a/server/src/features/player-assignment/utils/removeInvalidSignupsFromUsers.test.ts
+++ b/server/src/features/player-assignment/utils/removeInvalidSignupsFromUsers.test.ts
@@ -1,13 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { UserModel } from "server/features/user/userSchema";
 import { GameModel } from "server/features/game/gameSchema";
@@ -17,24 +9,14 @@ import { removeInvalidGamesFromUsers } from "server/features/player-assignment/u
 import { saveUser } from "server/features/user/userRepository";
 import { saveSignedGames } from "server/features/user/signed-game/signedGameRepository";
 
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("should remove signups for invalid games from users", async () => {

--- a/server/src/features/player-assignment/utils/removeOverlapSignups.test.ts
+++ b/server/src/features/player-assignment/utils/removeOverlapSignups.test.ts
@@ -1,6 +1,5 @@
-import { expect, test, afterEach, beforeAll, beforeEach } from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { removeOverlapSignups } from "server/features/player-assignment/utils/removeOverlapSignups";
 import { mockUser, mockSignedGames } from "server/test/mock-data/mockUser";
@@ -11,24 +10,14 @@ import { findGames, saveGames } from "server/features/game/gameRepository";
 import { saveSignedGames } from "server/features/user/signed-game/signedGameRepository";
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterEach(async () => {
-  await mongoServer.stop();
 });
 
 test("should remove overlapping signups from user", async () => {

--- a/server/src/features/player-assignment/utils/saveUserSignupResults.test.ts
+++ b/server/src/features/player-assignment/utils/saveUserSignupResults.test.ts
@@ -1,13 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { findUsers, saveUser } from "server/features/user/userRepository";
 import { testGame } from "shared/tests/testGame";
@@ -23,24 +15,14 @@ import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 import { saveUserSignupResults } from "server/features/player-assignment/utils/saveUserSignupResults";
 import { AssignmentResult } from "shared/typings/models/result";
 
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("should not add event log items after assigment if signup is dropped due to error", async () => {

--- a/server/src/features/player-assignment/utils/updateMovedGames.test.ts
+++ b/server/src/features/player-assignment/utils/updateMovedGames.test.ts
@@ -1,7 +1,6 @@
-import { expect, test, afterEach, beforeAll, beforeEach } from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import dayjs from "dayjs";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { UserModel } from "server/features/user/userSchema";
 import { GameModel } from "server/features/game/gameSchema";
@@ -13,24 +12,14 @@ import { saveSignedGames } from "server/features/user/signed-game/signedGameRepo
 import { findGames, saveGames } from "server/features/game/gameRepository";
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterEach(async () => {
-  await mongoServer.stop();
 });
 
 test("should remove lottery signups for moved games from users", async () => {

--- a/server/src/features/results/resultsController.test.ts
+++ b/server/src/features/results/resultsController.test.ts
@@ -1,28 +1,15 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { startServer, closeServer } from "server/utils/server";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -30,10 +17,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test(`GET ${ApiEndpoint.RESULTS} should return 422 without any parameters`, async () => {

--- a/server/src/features/results/resultsRepository.test.ts
+++ b/server/src/features/results/resultsRepository.test.ts
@@ -1,36 +1,18 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { ResultsModel } from "server/features/results/resultsSchema";
 import { AssignmentResult } from "shared/typings/models/result";
 import { saveResult } from "server/features/results/resultsRepository";
 
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("should insert new result into collection", async () => {

--- a/server/src/features/serial/serialRepository.test.ts
+++ b/server/src/features/serial/serialRepository.test.ts
@@ -1,14 +1,5 @@
-import {
-  expect,
-  test,
-  vi,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, vi, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { saveSerials } from "server/features/serial/serialRepository";
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
@@ -46,24 +37,14 @@ vi.mock("generate-serial-number", () => {
   };
 });
 
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("should insert new serial into collection", async () => {

--- a/server/src/features/settings/settingsController.test.ts
+++ b/server/src/features/settings/settingsController.test.ts
@@ -1,15 +1,6 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  beforeAll,
-  describe,
-  afterEach,
-  beforeEach,
-} from "vitest";
+import { expect, test, describe, afterEach, beforeEach } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { UserGroup } from "shared/typings/models/user";
@@ -46,15 +37,10 @@ import {
 } from "server/features/settings/settingsRepository";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -62,10 +48,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`GET ${ApiEndpoint.SETTINGS}`, () => {

--- a/server/src/features/settings/settingsRepository.test.ts
+++ b/server/src/features/settings/settingsRepository.test.ts
@@ -1,13 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { SettingsModel } from "server/features/settings/settingsSchema";
 import { testGame, testGame2 } from "shared/tests/testGame";
@@ -24,24 +16,14 @@ import {
 } from "shared/typings/models/settings";
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("should set defaults if settings not found", async () => {

--- a/server/src/features/signup/signupController.test.ts
+++ b/server/src/features/signup/signupController.test.ts
@@ -1,16 +1,6 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  vi,
-} from "vitest";
+import { expect, test, afterEach, beforeEach, describe, vi } from "vitest";
 import request, { Test } from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import dayjs from "dayjs";
 import { startServer, closeServer } from "server/utils/server";
@@ -44,15 +34,10 @@ import { DIRECT_SIGNUP_PRIORITY } from "shared/constants/signups";
 import * as signupTimes from "shared/utils/signupTimes";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -60,10 +45,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`POST ${ApiEndpoint.SIGNUP}`, () => {

--- a/server/src/features/signup/signupRepository.test.ts
+++ b/server/src/features/signup/signupRepository.test.ts
@@ -1,13 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import dayjs from "dayjs";
 import { saveUser } from "server/features/user/userRepository";
@@ -28,24 +20,14 @@ import {
 } from "server/features/signup/signupRepository";
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("should add new signup for user", async () => {

--- a/server/src/features/user/event-log/eventLogRepository.test.ts
+++ b/server/src/features/user/event-log/eventLogRepository.test.ts
@@ -1,13 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { UserModel } from "server/features/user/userSchema";
 import { findUser, saveUser } from "server/features/user/userRepository";
@@ -21,24 +13,14 @@ import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 import { saveGames } from "server/features/game/gameRepository";
 import { testGame, testGame2 } from "shared/tests/testGame";
 
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("should insert new event log item to user", async () => {

--- a/server/src/features/user/favorite-game/favoriteGameController.test.ts
+++ b/server/src/features/user/favorite-game/favoriteGameController.test.ts
@@ -1,15 +1,6 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  beforeAll,
-  describe,
-  beforeEach,
-  afterEach,
-} from "vitest";
+import { expect, test, describe, beforeEach, afterEach } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { UserGroup } from "shared/typings/models/user";
@@ -17,15 +8,10 @@ import { getJWT } from "server/utils/jwt";
 import { closeServer, startServer } from "server/utils/server";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -33,10 +19,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`POST ${ApiEndpoint.FAVORITE}`, () => {

--- a/server/src/features/user/group/groupController.test.ts
+++ b/server/src/features/user/group/groupController.test.ts
@@ -1,15 +1,6 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-} from "vitest";
+import { expect, test, afterEach, beforeEach, describe } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import dayjs from "dayjs";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
@@ -35,15 +26,10 @@ import { saveTestSettings } from "server/test/test-settings/testSettingsReposito
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -51,10 +37,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`GET ${ApiEndpoint.GROUP}`, () => {

--- a/server/src/features/user/login/loginController.test.ts
+++ b/server/src/features/user/login/loginController.test.ts
@@ -1,29 +1,15 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  beforeAll,
-  describe,
-  beforeEach,
-  afterEach,
-} from "vitest";
+import { expect, test, describe, beforeEach, afterEach } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { closeServer, startServer } from "server/utils/server";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -31,10 +17,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`POST ${ApiEndpoint.LOGIN}`, () => {

--- a/server/src/features/user/session-restore/sessionRestoreController.test.ts
+++ b/server/src/features/user/session-restore/sessionRestoreController.test.ts
@@ -1,15 +1,6 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  beforeAll,
-  describe,
-  beforeEach,
-  afterEach,
-} from "vitest";
+import { expect, test, describe, beforeEach, afterEach } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { mockUser } from "server/test/mock-data/mockUser";
@@ -18,15 +9,10 @@ import { closeServer, startServer } from "server/utils/server";
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -34,10 +20,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`POST ${ApiEndpoint.SESSION_RESTORE}`, () => {

--- a/server/src/features/user/signed-game/signedGameController.test.ts
+++ b/server/src/features/user/signed-game/signedGameController.test.ts
@@ -1,15 +1,6 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  beforeAll,
-  describe,
-  beforeEach,
-  afterEach,
-} from "vitest";
+import { expect, test, describe, beforeEach, afterEach } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { getJWT } from "server/utils/jwt";
@@ -17,15 +8,10 @@ import { UserGroup } from "shared/typings/models/user";
 import { closeServer, startServer } from "server/utils/server";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -33,10 +19,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`POST ${ApiEndpoint.SIGNED_GAME}`, () => {

--- a/server/src/features/user/signup-message/signupMessageController.test.ts
+++ b/server/src/features/user/signup-message/signupMessageController.test.ts
@@ -1,15 +1,6 @@
 import { Server } from "http";
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  expect,
-  test,
-  describe,
-} from "vitest";
+import { afterEach, beforeEach, expect, test, describe } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { getJWT } from "server/utils/jwt";
@@ -34,15 +25,10 @@ import {
 import { saveSignup } from "server/features/signup/signupRepository";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -50,10 +36,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`GET ${ApiEndpoint.SIGNUP_MESSAGE}`, () => {

--- a/server/src/features/user/userController.test.ts
+++ b/server/src/features/user/userController.test.ts
@@ -1,16 +1,6 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  vi,
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  beforeEach,
-} from "vitest";
+import { expect, test, vi, afterEach, describe, beforeEach } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { UserGroup } from "shared/typings/models/user";
@@ -19,15 +9,10 @@ import { closeServer, startServer } from "server/utils/server";
 import { config } from "shared/config";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -35,10 +20,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`GET ${ApiEndpoint.USERS}`, () => {

--- a/server/src/features/user/userControllerPasswordReset.test.ts
+++ b/server/src/features/user/userControllerPasswordReset.test.ts
@@ -1,15 +1,6 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, describe, beforeEach } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { UserGroup } from "shared/typings/models/user";
@@ -19,15 +10,10 @@ import { mockUser } from "server/test/mock-data/mockUser";
 import { closeServer, startServer } from "server/utils/server";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -35,10 +21,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe(`POST ${ApiEndpoint.USERS_PASSWORD}`, () => {

--- a/server/src/features/user/userRepository.test.ts
+++ b/server/src/features/user/userRepository.test.ts
@@ -1,13 +1,5 @@
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import {
   findUser,
@@ -19,24 +11,14 @@ import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
 import { testGame } from "shared/tests/testGame";
 import { saveGames } from "server/features/game/gameRepository";
 
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
-
 beforeEach(async () => {
-  await mongoose.connect(mongoServer.getUri(), {
+  await mongoose.connect(globalThis.__MONGO_URI__, {
     dbName: faker.string.alphanumeric(10),
   });
 });
 
 afterEach(async () => {
   await mongoose.disconnect();
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("should insert new user into collection", async () => {

--- a/server/src/test/global.d.ts
+++ b/server/src/test/global.d.ts
@@ -1,0 +1,5 @@
+// eslint-disable-next-line no-var
+declare var __MONGO_URI__: string;
+
+// eslint-disable-next-line no-var
+declare var __MONGO_DB__: import("mongodb-memory-server").MongoMemoryServer;

--- a/server/src/test/mongoDdMemoryServerSetup.ts
+++ b/server/src/test/mongoDdMemoryServerSetup.ts
@@ -1,0 +1,19 @@
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+interface Options {
+  serverOptions?: NonNullable<
+    Parameters<(typeof MongoMemoryServer)["create"]>[0]
+  >;
+}
+
+export const setupMongoDbMemoryServer = async (
+  options?: Options,
+): Promise<void> => {
+  const serverOptions = options?.serverOptions;
+  globalThis.__MONGO_DB__ = await MongoMemoryServer.create(serverOptions);
+  globalThis.__MONGO_URI__ = globalThis.__MONGO_DB__.getUri();
+};
+
+export const teardownMongoDbMemoryServer = async (): Promise<void> => {
+  await globalThis.__MONGO_DB__.stop();
+};

--- a/server/src/test/setupTests.ts
+++ b/server/src/test/setupTests.ts
@@ -1,7 +1,11 @@
-import { vi } from "vitest";
+import { afterAll, beforeAll, vi } from "vitest";
 import { initializeDayjs } from "shared/utils/initializeDayjs";
 import { config } from "shared/config";
 import { ProgramType } from "shared/typings/models/game";
+import {
+  setupMongoDbMemoryServer,
+  teardownMongoDbMemoryServer,
+} from "server/test/mongoDdMemoryServerSetup";
 
 initializeDayjs();
 
@@ -27,4 +31,12 @@ vi.spyOn(config, "shared").mockReturnValue({
   conventionEndTime: "2023-07-30T21:00:00Z", // Sun 24:00 GMT+3
   directSignupAlwaysOpenIds: ["1234"],
   twoPhaseSignupProgramTypes: [ProgramType.TABLETOP_RPG, ProgramType.LARP],
+});
+
+beforeAll(async () => {
+  await setupMongoDbMemoryServer();
+});
+
+afterAll(async () => {
+  await teardownMongoDbMemoryServer();
 });

--- a/server/src/test/test-data-generation/testDataController.test.ts
+++ b/server/src/test/test-data-generation/testDataController.test.ts
@@ -1,36 +1,17 @@
-import {
-  expect,
-  test,
-  vi,
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-} from "vitest";
+import { expect, test, vi, afterEach, describe } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { startTestServer, stopTestServer } from "server/test/utils/testServer";
-
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 afterEach(() => {
   // Start server with different process.env.SETTINGS
   vi.resetModules();
 });
 
-afterAll(async () => {
-  await mongoServer.stop();
-});
-
 describe(`POST ${ApiEndpoint.POPULATE_DB}`, () => {
   test("should return 404 on production", async () => {
     vi.stubEnv("SETTINGS", "production");
-    const { server } = await startTestServer(mongoServer.getUri());
+    const { server } = await startTestServer(globalThis.__MONGO_URI__);
 
     try {
       const response = await request(server).post(ApiEndpoint.POPULATE_DB);

--- a/server/src/test/test-settings/testSettingsController.test.ts
+++ b/server/src/test/test-settings/testSettingsController.test.ts
@@ -1,37 +1,18 @@
-import {
-  expect,
-  test,
-  vi,
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-} from "vitest";
+import { expect, test, vi, afterEach, describe } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { startTestServer, stopTestServer } from "server/test/utils/testServer";
 import { TestSettings } from "shared/test-typings/models/testSettings";
-
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 afterEach(() => {
   // Start server with different process.env.SETTINGS
   vi.resetModules();
 });
 
-afterAll(async () => {
-  await mongoServer.stop();
-});
-
 describe(`GET ${ApiEndpoint.TEST_SETTINGS}`, () => {
   test("should return 404 on production", async () => {
     vi.stubEnv("SETTINGS", "production");
-    const { server } = await startTestServer(mongoServer.getUri());
+    const { server } = await startTestServer(globalThis.__MONGO_URI__);
 
     try {
       const response = await request(server).get(ApiEndpoint.TEST_SETTINGS);
@@ -43,7 +24,7 @@ describe(`GET ${ApiEndpoint.TEST_SETTINGS}`, () => {
 
   test("should return default settings", async () => {
     vi.stubEnv("SETTINGS", "development");
-    const { server } = await startTestServer(mongoServer.getUri());
+    const { server } = await startTestServer(globalThis.__MONGO_URI__);
 
     try {
       const response = await request(server).get(ApiEndpoint.TEST_SETTINGS);
@@ -62,7 +43,7 @@ describe(`GET ${ApiEndpoint.TEST_SETTINGS}`, () => {
 describe(`POST ${ApiEndpoint.TEST_SETTINGS}`, () => {
   test("should return 404 on production", async () => {
     vi.stubEnv("SETTINGS", "production");
-    const { server } = await startTestServer(mongoServer.getUri());
+    const { server } = await startTestServer(globalThis.__MONGO_URI__);
 
     try {
       const response = await request(server).post(ApiEndpoint.TEST_SETTINGS);
@@ -74,7 +55,7 @@ describe(`POST ${ApiEndpoint.TEST_SETTINGS}`, () => {
 
   test("should return 422 with invalid body", async () => {
     vi.stubEnv("SETTINGS", "development");
-    const { server } = await startTestServer(mongoServer.getUri());
+    const { server } = await startTestServer(globalThis.__MONGO_URI__);
 
     try {
       const response = await request(server)
@@ -88,7 +69,7 @@ describe(`POST ${ApiEndpoint.TEST_SETTINGS}`, () => {
 
   test("should return updated test settings after update", async () => {
     vi.stubEnv("SETTINGS", "development");
-    const { server } = await startTestServer(mongoServer.getUri());
+    const { server } = await startTestServer(globalThis.__MONGO_URI__);
 
     try {
       const testSettings: TestSettings = {

--- a/server/src/utils/cron.test.ts
+++ b/server/src/utils/cron.test.ts
@@ -2,14 +2,12 @@ import { Server } from "http";
 import {
   expect,
   test,
-  afterAll,
   afterEach,
   beforeAll,
   beforeEach,
   vi,
   describe,
 } from "vitest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import dayjs from "dayjs";
 import { startServer, closeServer } from "server/utils/server";
@@ -28,21 +26,19 @@ import { logger } from "server/utils/logger";
 import { saveTestSettings } from "server/test/test-settings/testSettingsRepository";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
 
 const timeNow = "2019-07-26T17:00:00.000Z";
 const previousJobRunning = 30; // Seconds since last run
 const previousJobFinished = 31; // Seconds since last run
 
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
+beforeAll(() => {
   // vi.useFakeTimers();
   vi.setSystemTime(timeNow);
 });
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -53,10 +49,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 describe("Progam update cronjob", () => {

--- a/server/src/utils/server.test.ts
+++ b/server/src/utils/server.test.ts
@@ -1,27 +1,14 @@
 import { Server } from "http";
-import {
-  expect,
-  test,
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { expect, test, afterEach, beforeEach } from "vitest";
 import request from "supertest";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { startServer, closeServer } from "server/utils/server";
 
 let server: Server;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-});
 
 beforeEach(async () => {
   server = await startServer({
-    dbConnString: mongoServer.getUri(),
+    dbConnString: globalThis.__MONGO_URI__,
     dbName: faker.string.alphanumeric(10),
     enableSentry: false,
   });
@@ -29,10 +16,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await closeServer(server);
-});
-
-afterAll(async () => {
-  await mongoServer.stop();
 });
 
 test("should return 400 if request is not valid json", async () => {


### PR DESCRIPTION
* Start single `mongodb-memory-server` before all tests
* Previously each test file started new server
* Inspiration
  * https://nodkz.github.io/mongodb-memory-server/docs/guides/integration-examples/test-runners/
  * https://github.com/ec965/vitest-mongodb