### PR TITLE
Use lodash-es with named imports, replace ts-node with tsx

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,9 +4,4 @@ enableConstraintsChecks: true
 
 nodeLinker: node-modules
 
-packageExtensions:
-  ts-node-dev@*:
-    peerDependencies:
-      "@types/node": "*" # Workaround for https://github.com/wclr/ts-node-dev/issues/319
-
 yarnPath: .yarn/releases/yarn-4.0.2.cjs

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,7 @@ module.exports = (api) => {
 
   const presets = ["@babel/typescript"];
 
-  const plugins = ["babel-plugin-lodash"];
+  const plugins = [];
 
   if (target === "start") {
     plugins.push(["react-refresh/babel"]);

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "name": "Arttu Hanska"
   },
   "main": "index.tsx",
+  "type:": "module",
   "scripts": {
     "build:ci": "yarn clean && webpack-cli",
     "build:dev": "yarn clean && webpack-cli",

--- a/client/src/test/test-components/TestTime.tsx
+++ b/client/src/test/test-components/TestTime.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, ReactElement, useEffect, useState } from "react";
 import styled from "styled-components";
-import _ from "lodash";
+import { first, capitalize } from "lodash-es";
 import dayjs from "dayjs";
 import { useTranslation } from "react-i18next";
 import { testTimes } from "client/test/test-components/testComponentUtils";
@@ -23,7 +23,7 @@ export const TestTime = (): ReactElement => {
 
   useEffect(() => {
     const setInitialTestTime = async (): Promise<void> => {
-      const defaultTestTime = _.first(testTimes);
+      const defaultTestTime = first(testTimes);
       if (!testTime && defaultTestTime) {
         await dispatch(submitSetTestSettings({ testTime: defaultTestTime }));
       }
@@ -49,8 +49,8 @@ export const TestTime = (): ReactElement => {
   const dropdownItems = testTimes.map((time) => {
     const formattedDate =
       i18n.language === "fi"
-        ? `${_.capitalize(getShortWeekdayAndTime(time))} (${getDate(time)})`
-        : `${_.capitalize(getShortWeekdayAndTime(time))} (${getDate(time)})`;
+        ? `${capitalize(getShortWeekdayAndTime(time))} (${getDate(time)})`
+        : `${capitalize(getShortWeekdayAndTime(time))} (${getDate(time)})`;
     return { value: time, title: formattedDate };
   });
 
@@ -71,8 +71,8 @@ export const TestTime = (): ReactElement => {
           // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- Test value
           <div onClick={() => setDropdownVisible(true)}>
             {i18n.language === "fi"
-              ? _.capitalize(getShortWeekdayAndTime(testTime))
-              : _.capitalize(getShortWeekdayAndTime(testTime))}
+              ? capitalize(getShortWeekdayAndTime(testTime))
+              : capitalize(getShortWeekdayAndTime(testTime))}
           </div>
         )}
       </StyledTestTime>

--- a/client/src/utils/localStorage.ts
+++ b/client/src/utils/localStorage.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { merge } from "lodash-es";
 import { z } from "zod";
 import { LocalStorageState } from "client/types/reduxTypes";
 import { ProgramType } from "shared/types/models/game";
@@ -48,7 +48,7 @@ export const loadSession = (): LocalStorage | undefined => {
 
 export const saveSession = (state: Partial<LocalStorageState>): void => {
   const previousSession = loadSession();
-  const newSession = previousSession ? _.merge(previousSession, state) : state;
+  const newSession = previousSession ? merge(previousSession, state) : state;
 
   try {
     const serializedState = JSON.stringify(newSession);

--- a/client/src/views/admin/AdminView.tsx
+++ b/client/src/views/admin/AdminView.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, ChangeEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled, { css } from "styled-components";
-import _ from "lodash";
+import { capitalize } from "lodash-es";
 import { HiddenGamesList } from "client/views/admin/components/HiddenGamesList";
 import {
   submitGetSentryTest,
@@ -61,7 +61,7 @@ export const AdminView = (): ReactElement => {
     const times = [...Array.from(new Set(startTimes))].sort();
 
     return times.map((time) => {
-      const formattedDate = _.capitalize(getWeekdayAndTime(time));
+      const formattedDate = capitalize(getWeekdayAndTime(time));
       return { value: time, title: formattedDate };
     });
   };

--- a/client/src/views/admin/adminSlice.ts
+++ b/client/src/views/admin/adminSlice.ts
@@ -1,5 +1,5 @@
 import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
-import _ from "lodash";
+import { uniq } from "lodash-es";
 import { BackendErrorType } from "client/components/ErrorBar";
 import { AdminState, RootState } from "client/types/reduxTypes";
 import { SettingsPayload } from "shared/types/api/settings";
@@ -82,7 +82,7 @@ const adminSlice = createSlice({
     addError(state, action: PayloadAction<BackendErrorType>) {
       return {
         ...state,
-        errors: _.uniq([...state.errors, action.payload]),
+        errors: uniq([...state.errors, action.payload]),
       };
     },
 

--- a/client/src/views/admin/components/HiddenGamesList.tsx
+++ b/client/src/views/admin/components/HiddenGamesList.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-import _ from "lodash";
+import { sortBy } from "lodash-es";
 import { getWeekdayAndTime } from "client/utils/timeFormatter";
 import { Game } from "shared/types/models/game";
 
@@ -12,7 +12,7 @@ interface Props {
 export const HiddenGamesList = ({ hiddenGames }: Props): ReactElement => {
   const { t } = useTranslation();
 
-  const sortedGames = _.sortBy(hiddenGames, [
+  const sortedGames = sortBy(hiddenGames, [
     (hiddenGame) => hiddenGame.title.toLowerCase(),
   ]);
 

--- a/client/src/views/admin/components/SignupQuestionList.tsx
+++ b/client/src/views/admin/components/SignupQuestionList.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
-import _ from "lodash";
+import { sortBy } from "lodash-es";
 import { Game } from "shared/types/models/game";
 import { SignupQuestion } from "shared/types/models/settings";
 import { getWeekdayAndTime } from "client/utils/timeFormatter";
@@ -30,7 +30,7 @@ export const SignupQuestionList = ({
     },
   );
 
-  const sortedSignupQuestions = _.sortBy(signupQuestionsWithGames, [
+  const sortedSignupQuestions = sortBy(signupQuestionsWithGames, [
     "game.startTime",
     (signupQuestion) => signupQuestion.game.title.toLocaleLowerCase(),
   ]);

--- a/client/src/views/all-games/components/AllGamesList.tsx
+++ b/client/src/views/all-games/components/AllGamesList.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
-import _ from "lodash";
+import { sortBy, groupBy } from "lodash-es";
 import styled from "styled-components";
 import { GameEntry } from "./GameEntry";
 import { useAppSelector } from "client/utils/hooks";
@@ -43,12 +43,12 @@ export const AllGamesList = ({ games }: Props): ReactElement => {
     getAllGames: true,
   });
 
-  const sortedGames = _.sortBy(games, [
+  const sortedGames = sortBy(games, [
     (game) => game.startTime,
     (game) => game.title.toLowerCase(),
   ]);
 
-  const gamesByStartTime = _.groupBy(sortedGames, "startTime");
+  const gamesByStartTime = groupBy(sortedGames, "startTime");
 
   const gamesList = Object.entries(gamesByStartTime).map(
     ([startTime, gamesForStartTime]) => {

--- a/client/src/views/all-games/components/EventLog.tsx
+++ b/client/src/views/all-games/components/EventLog.tsx
@@ -3,7 +3,7 @@ import dayjs from "dayjs";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-import _ from "lodash";
+import { orderBy } from "lodash-es";
 import { useAppDispatch, useAppSelector } from "client/utils/hooks";
 import { submitUpdateEventLogIsSeen } from "client/views/login/loginThunks";
 import { getWeekdayAndTime } from "client/utils/timeFormatter";
@@ -57,7 +57,7 @@ export const EventLog = (): ReactElement => {
         <RaisedCard>{t("eventLog.noNotifications")}</RaisedCard>
       )}
 
-      {_.orderBy(
+      {orderBy(
         localEventLogItems.current,
         (item) => item.createdAt,
         "desc",

--- a/client/src/views/all-games/components/GameEntry.tsx
+++ b/client/src/views/all-games/components/GameEntry.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-import _ from "lodash";
+import { capitalize } from "lodash-es";
 import { updateFavorite, UpdateFavoriteOpts } from "client/utils/favorite";
 import { useAppDispatch, useAppSelector } from "client/utils/hooks";
 import { SignupStrategy } from "shared/config/sharedConfigTypes";
@@ -136,7 +136,7 @@ export const GameEntry = ({
               game.maxAttendance > 0 && (
                 <RowItem>
                   {game.minAttendance === game.maxAttendance &&
-                    _.capitalize(
+                    capitalize(
                       `${t(
                         `attendeeTypePlural.${getAttendeeType(
                           game.programType,
@@ -145,7 +145,7 @@ export const GameEntry = ({
                     )}
 
                   {game.minAttendance !== game.maxAttendance &&
-                    _.capitalize(
+                    capitalize(
                       `${t(
                         `attendeeTypePlural.${getAttendeeType(
                           game.programType,

--- a/client/src/views/all-games/components/GameInfo.tsx
+++ b/client/src/views/all-games/components/GameInfo.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import styled, { css } from "styled-components";
-import _ from "lodash";
+import { capitalize } from "lodash-es";
 import { getWeekdayAndTime, getTime } from "client/utils/timeFormatter";
 import { Game, GameStyle, Genre } from "shared/types/models/game";
 
@@ -49,7 +49,7 @@ export const GameInfo = ({ game }: Props): ReactElement => {
   });
 
   const getFormattedStartTime = (startTime: string): string =>
-    _.capitalize(getWeekdayAndTime(startTime));
+    capitalize(getWeekdayAndTime(startTime));
 
   const getFormattedEndTime = (endTime: string): string => getTime(endTime);
 

--- a/client/src/views/all-games/components/GameListTitle.tsx
+++ b/client/src/views/all-games/components/GameListTitle.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, useRef } from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
-import _ from "lodash";
+import { capitalize } from "lodash-es";
 import { getTime, getWeekdayAndTime } from "client/utils/timeFormatter";
 import { SelectedGame } from "shared/types/models/user";
 import { SignupStrategy } from "shared/config/sharedConfigTypes";
@@ -32,7 +32,7 @@ export const GameListTitle = ({
   const { t } = useTranslation();
   const intersectionRef = useRef<HTMLDivElement | null>(null);
 
-  const formattedStartTime = _.capitalize(getWeekdayAndTime(startTime));
+  const formattedStartTime = capitalize(getWeekdayAndTime(startTime));
 
   const algorithmSignupStartTime = getTime(
     getAlgorithmSignupStartTime(startTime).toISOString(),

--- a/client/src/views/helper/components/PrivateSignupMessages.tsx
+++ b/client/src/views/helper/components/PrivateSignupMessages.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import _ from "lodash";
+import { groupBy, sortBy, capitalize } from "lodash-es";
 import styled from "styled-components";
 import { useAppSelector } from "client/utils/hooks";
 import { Game } from "shared/types/models/game";
@@ -40,8 +40,8 @@ export const PrivateSignupMessages = (): ReactElement => {
     },
   );
 
-  const groupedSignupQuestions = _.groupBy(
-    _.sortBy(signupQuestionsWithGames, "game.startTime"),
+  const groupedSignupQuestions = groupBy(
+    sortBy(signupQuestionsWithGames, "game.startTime"),
     "game.startTime",
   );
 
@@ -49,7 +49,7 @@ export const PrivateSignupMessages = (): ReactElement => {
     (signupMessage) => signupMessage.private,
   );
 
-  const groupedSignupMessages = _.groupBy(privateSignupMessages, "gameId");
+  const groupedSignupMessages = groupBy(privateSignupMessages, "gameId");
 
   useEffect(() => {
     if (searchTerm.length === 0) {
@@ -92,13 +92,13 @@ export const PrivateSignupMessages = (): ReactElement => {
 
       {Object.entries(groupedSignupQuestions).map(
         ([startTime, signupQuestionsWithGame]) => {
-          const sortedSignupQuestions = _.sortBy(signupQuestionsWithGame, [
+          const sortedSignupQuestions = sortBy(signupQuestionsWithGame, [
             (signupQuestion) => signupQuestion.game.title.toLocaleLowerCase(),
           ]);
 
           return (
             <div key={startTime}>
-              <h3>{_.capitalize(getWeekdayAndTime(startTime))}</h3>
+              <h3>{capitalize(getWeekdayAndTime(startTime))}</h3>
               {sortedSignupQuestions.map((signupQuestionWithGame) => {
                 const matchingSignupMessages =
                   groupedSignupMessages[signupQuestionWithGame.gameId];

--- a/client/src/views/my-games/components/FavoritesByStartTimes.tsx
+++ b/client/src/views/my-games/components/FavoritesByStartTimes.tsx
@@ -2,7 +2,7 @@ import { Fragment, ReactElement } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
-import _ from "lodash";
+import { capitalize } from "lodash-es";
 import { getWeekdayAndTime } from "client/utils/timeFormatter";
 import { Game } from "shared/types/models/game";
 import { useAppDispatch, useAppSelector } from "client/utils/hooks";
@@ -39,9 +39,7 @@ export const FavoritesByStartTimes = ({
       {startTimes.map((startTime) => {
         return (
           <Fragment key={startTime}>
-            <StyledTime>
-              {_.capitalize(getWeekdayAndTime(startTime))}
-            </StyledTime>
+            <StyledTime>{capitalize(getWeekdayAndTime(startTime))}</StyledTime>
 
             <ul>
               {games.map((game) => {

--- a/client/src/views/my-games/components/MyEnteredList.tsx
+++ b/client/src/views/my-games/components/MyEnteredList.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import _ from "lodash";
+import { sortBy, uniq } from "lodash-es";
 import styled from "styled-components";
 import { ResultsByStartTimes } from "./ResultsByStartTimes";
 import { getMissedSignups } from "client/views/my-games/utils/getMissedSignups";
@@ -43,8 +43,8 @@ export const MyEnteredList = ({
 
       {config.shared().resultsVisible && startTimes.length !== 0 && (
         <ResultsByStartTimes
-          signups={_.sortBy(enteredGames, [(enteredGame) => enteredGame.time])}
-          startTimes={_.uniq(startTimes).sort()}
+          signups={sortBy(enteredGames, [(enteredGame) => enteredGame.time])}
+          startTimes={uniq(startTimes).sort()}
           missedSignups={missedSignups}
         />
       )}

--- a/client/src/views/my-games/components/MyFavoritesList.tsx
+++ b/client/src/views/my-games/components/MyFavoritesList.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import _ from "lodash";
+import { sortBy } from "lodash-es";
 import styled from "styled-components";
 import { getStartTimes } from "client/utils/getStartTimes";
 import { FavoritesByStartTimes } from "./FavoritesByStartTimes";
@@ -14,7 +14,7 @@ interface Props {
 export const MyFavoritesList = ({ favoritedGames }: Props): ReactElement => {
   const { t } = useTranslation();
 
-  const sortedGames: readonly Game[] = _.sortBy(favoritedGames, [
+  const sortedGames: readonly Game[] = sortBy(favoritedGames, [
     (favoritedGame) => favoritedGame.startTime,
     (favoritedGame) => favoritedGame.title.toLowerCase(),
   ]);

--- a/client/src/views/my-games/components/MySignupsList.tsx
+++ b/client/src/views/my-games/components/MySignupsList.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import _ from "lodash";
+import { sortBy } from "lodash-es";
 import styled from "styled-components";
 import { getStartTimes } from "client/utils/getStartTimes";
 import { SignupsByStartTimes } from "./SignupsByStartTimes";
@@ -23,7 +23,7 @@ export const MySignupsList = ({
 
   const groupMembers = useAppSelector((state) => state.group.groupMembers);
 
-  const sortedSignups = _.sortBy(signedGames, [
+  const sortedSignups = sortBy(signedGames, [
     (signedGame) => signedGame.gameDetails.startTime,
     (signedGame) => signedGame.priority,
   ]);

--- a/client/src/views/my-games/components/ResultsByStartTimes.tsx
+++ b/client/src/views/my-games/components/ResultsByStartTimes.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
-import _ from "lodash";
+import { capitalize } from "lodash-es";
 import { getWeekdayAndTime } from "client/utils/timeFormatter";
 import { SelectedGame } from "shared/types/models/user";
 import { EnteredGameRow } from "client/views/my-games/components/EnteredGameRow";
@@ -24,9 +24,7 @@ export const ResultsByStartTimes = ({
       {startTimes.map((startTime) => {
         return (
           <div key={startTime}>
-            <StyledTime>
-              {_.capitalize(getWeekdayAndTime(startTime))}
-            </StyledTime>
+            <StyledTime>{capitalize(getWeekdayAndTime(startTime))}</StyledTime>
 
             <ul>
               {signups.map((signup) => {

--- a/client/src/views/my-games/components/SignupsByStartTimes.tsx
+++ b/client/src/views/my-games/components/SignupsByStartTimes.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
-import _ from "lodash";
+import { capitalize } from "lodash-es";
 import { getWeekdayAndTime } from "client/utils/timeFormatter";
 import { SelectedGame } from "shared/types/models/user";
 import { PopularityInfo } from "client/components/PopularityInfo";
@@ -20,9 +20,7 @@ export const SignupsByStartTimes = ({
       {startTimes.map((startTime) => {
         return (
           <div key={startTime}>
-            <StyledTime>
-              {_.capitalize(getWeekdayAndTime(startTime))}
-            </StyledTime>
+            <StyledTime>{capitalize(getWeekdayAndTime(startTime))}</StyledTime>
 
             <ul>
               {signups.map((signup) => {

--- a/client/src/views/results/components/ResultsList.tsx
+++ b/client/src/views/results/components/ResultsList.tsx
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { sortBy, isEqual, groupBy, capitalize } from "lodash-es";
 import { ReactElement, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
@@ -64,8 +64,8 @@ export const ResultsList = (): ReactElement => {
 
   const filteredGames =
     selectedStartingTime === ResultsStartingTimeOption.ALL
-      ? _.sortBy(visibleGames, "startTime")
-      : _.sortBy(getUpcomingGames(visibleGames, 1), "startTime");
+      ? sortBy(visibleGames, "startTime")
+      : sortBy(getUpcomingGames(visibleGames, 1), "startTime");
 
   const [gamesForListing, setGamesForListing] = useState<readonly Game[]>([]);
   const [filteredGamesForListing, setFilteredGamesForListing] = useState<
@@ -74,7 +74,7 @@ export const ResultsList = (): ReactElement => {
   const [searchTerm, setSearchTerm] = useState<string>("");
 
   useEffect(() => {
-    if (_.isEqual(filteredGames, gamesForListing)) {
+    if (isEqual(filteredGames, gamesForListing)) {
       return;
     }
 
@@ -83,7 +83,7 @@ export const ResultsList = (): ReactElement => {
 
   useEffect(() => {
     if (searchTerm.length === 0) {
-      const gamesByStartTime = _.groupBy<Game>(gamesForListing, "startTime");
+      const gamesByStartTime = groupBy<Game>(gamesForListing, "startTime");
       setFilteredGamesForListing(gamesByStartTime);
       return;
     }
@@ -103,7 +103,7 @@ export const ResultsList = (): ReactElement => {
       );
     });
 
-    const gamesByStartTime = _.groupBy<Game>(
+    const gamesByStartTime = groupBy<Game>(
       gamesFilteredBySearchTerm,
       "startTime",
     );
@@ -124,13 +124,13 @@ export const ResultsList = (): ReactElement => {
 
       {Object.entries(filteredGamesForListing).map(
         ([startTime, gamesForTime]) => {
-          const sortedGamesForTime = _.sortBy(gamesForTime, [
+          const sortedGamesForTime = sortBy(gamesForTime, [
             (game) => game.title.toLocaleLowerCase(),
           ]);
 
           return (
             <TimeSlot key={startTime}>
-              <h3>{_.capitalize(getWeekdayAndTime(startTime))}</h3>
+              <h3>{capitalize(getWeekdayAndTime(startTime))}</h3>
 
               <Games>
                 {sortedGamesForTime.map((game) => {
@@ -166,7 +166,7 @@ export const ResultsList = (): ReactElement => {
                           }}
                         >
                           <span>
-                            {_.capitalize(
+                            {capitalize(
                               t(
                                 `attendeeTypePlural.${getAttendeeType(
                                   game.programType,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "client",
     "server"
   ],
+  "type:": "module",
   "scripts": {
     "build-front:ci": "yarn workspace konsti-client build:ci && yarn copy-front",
     "build-front:dev": "yarn workspace konsti-client build:dev && yarn copy-front",
@@ -37,7 +38,7 @@
     "prettier:check": "prettier --check \"./**/*.{js,cjs,json,mdx,ts,mts,tsx,yml}\"",
     "prettier:write": "prettier --write \"./**/*.{js,cjs,json,mdx,ts,mts,tsx,yml}\"",
     "server": "yarn workspace konsti-server start:dev",
-    "start:dev": "yarn docker:db && concurrently --kill-others-on-fail \"yarn server\" \"yarn client\"",
+    "start:dev": "yarn docker:db && npm-run-all --parallel server client",
     "start": "yarn workspace konsti-server start",
     "stylelint": "yarn workspace konsti-client stylelint",
     "test-assign": "yarn workspace konsti-server test-assign",
@@ -56,12 +57,11 @@
     "@yarnpkg/types": "4.0.0",
     "axios": "1.6.2",
     "babel-plugin-module-resolver": "5.0.0",
-    "concurrently": "8.2.2",
     "dayjs": "1.11.10",
     "lodash-es": "4.17.21",
     "ncp": "2.0.0",
+    "npm-run-all": "4.1.5",
     "rimraf": "5.0.5",
-    "tsconfig-paths": "4.2.0",
     "typescript": "5.2.2",
     "zod": "3.22.4"
   },

--- a/package.json
+++ b/package.json
@@ -55,11 +55,10 @@
     "@babel/preset-typescript": "7.23.3",
     "@yarnpkg/types": "4.0.0",
     "axios": "1.6.2",
-    "babel-plugin-lodash": "3.3.4",
     "babel-plugin-module-resolver": "5.0.0",
     "concurrently": "8.2.2",
     "dayjs": "1.11.10",
-    "lodash": "4.17.21",
+    "lodash-es": "4.17.21",
     "ncp": "2.0.0",
     "rimraf": "5.0.5",
     "tsconfig-paths": "4.2.0",
@@ -67,7 +66,7 @@
     "zod": "3.22.4"
   },
   "devDependencies": {
-    "@types/lodash": "4.14.202",
+    "@types/lodash-es": "4.17.12",
     "@typescript-eslint/eslint-plugin": "6.12.0",
     "@typescript-eslint/parser": "6.12.0",
     "cross-env": "7.0.3",
@@ -99,7 +98,6 @@
   },
   "packageManager": "yarn@4.0.2",
   "resolutions": {
-    "babel-plugin-lodash/@babel/types": "7.20.7",
     "babel-plugin-styled-components": "2.1.3"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -7,28 +7,29 @@
     "name": "Arttu Hanska"
   },
   "main": "index.ts",
+  "type:": "module",
   "scripts": {
     "eslint": "yarn run -T eslint . --ext .js,.cjs,.ts,.mts",
     "eslint-save-config": "eslint --print-config .eslintrc.js > eslint-config-server.json && prettier --write eslint-config-server.json",
-    "fixer": "ts-node src/features/statistics/dataFixer.ts --",
-    "generate-data": "ts-node src/test/test-data-generation/parseCliOptions.ts",
-    "initialize-db": "ts-node src/utils/initializeDatabase.ts",
-    "generate-serials": "ts-node src/utils/generateSerials.ts",
+    "fixer": "tsx src/features/statistics/dataFixer.ts --",
+    "generate-data": "tsx src/test/test-data-generation/parseCliOptions.ts",
+    "initialize-db": "tsx src/utils/initializeDatabase.ts",
+    "generate-serials": "tsx src/utils/generateSerials.ts",
     "lint": "yarn eslint && yarn prettier:check",
-    "remove-invalid-games": "yarn run -T cross-env NODE_ENV=development ts-node src/test/scripts/removeInvalidGames.ts",
+    "remove-invalid-games": "yarn run -T cross-env NODE_ENV=development tsx src/test/scripts/removeInvalidGames.ts",
     "build": "yarn run -T rimraf dist/server && ncc build src/index.ts -o dist/server",
     "start-ncc": "node dist/server/index.js",
-    "start": "ts-node --transpile-only src/index.ts",
-    "start:dev": "yarn run -T cross-env NODE_ENV=development SETTINGS=development ts-node-dev -r tsconfig-paths/register -r dotenv/config --respawn --transpile-only src/index.ts dotenv_config_path=.env.development",
-    "stats": "ts-node src/features/statistics/statGenerator.ts --",
+    "start": "tsx src/index.ts",
+    "start:dev": "yarn run -T cross-env NODE_ENV=development SETTINGS=development tsx watch --clear-screen=false -r dotenv/config src/index.ts dotenv_config_path=.env.development",
+    "stats": "tsx src/features/statistics/statGenerator.ts --",
     "test": "yarn run -T vitest run",
-    "test-assign": "yarn run -T cross-env NODE_ENV=development ts-node src/test/scripts/testAssignPlayers.ts",
+    "test-assign": "yarn run -T cross-env NODE_ENV=development tsx src/test/scripts/testAssignPlayers.ts",
     "test:coverage": "yarn run -T vitest run --coverage --colors",
     "test:watch": "yarn run -T vitest watch",
     "type-check": "yarn run -T tsc --noEmit",
-    "update-game-popularity": "yarn run -T cross-env NODE_ENV=development ts-node src/test/scripts/testUpdateGamePopularity.ts",
-    "verify-results": "yarn run -T cross-env NODE_ENV=development ts-node src/test/scripts/testVerifyResults.ts",
-    "load-kompassi-data": "yarn run -T cross-env NODE_ENV=development ts-node src/test/scripts/loadKompassiDataToDb.ts"
+    "update-game-popularity": "yarn run -T cross-env NODE_ENV=development tsx src/test/scripts/testUpdateGamePopularity.ts",
+    "verify-results": "yarn run -T cross-env NODE_ENV=development tsx src/test/scripts/testVerifyResults.ts",
+    "load-kompassi-data": "yarn run -T cross-env NODE_ENV=development tsx src/test/scripts/loadKompassiDataToDb.ts"
   },
   "dependencies": {
     "@faker-js/faker": "8.3.1",
@@ -47,7 +48,7 @@
     "jsonwebtoken": "9.0.2",
     "mongoose": "8.0.1",
     "morgan": "1.10.0",
-    "ts-node": "10.9.1",
+    "tsx": "4.6.1",
     "winston": "3.11.0",
     "winston-transport-sentry-node": "2.7.0"
   },
@@ -58,8 +59,7 @@
     "@types/node": "18.18.12",
     "@types/supertest": "2.0.16",
     "mongodb-memory-server": "9.1.1",
-    "supertest": "6.3.3",
-    "ts-node-dev": "2.0.0"
+    "supertest": "6.3.3"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/server/src/features/game-popularity/utils/updateWithAssign.ts
+++ b/server/src/features/game-popularity/utils/updateWithAssign.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import _ from "lodash";
+import { countBy, groupBy } from "lodash-es";
 import { padgAssignPlayers } from "server/features/player-assignment/padg/padgAssignPlayers";
 import { User } from "shared/types/models/user";
 import { Game } from "shared/types/models/game";
@@ -21,7 +21,7 @@ export const updateWithAssign = async (
   games: readonly Game[],
   signups: readonly Signup[],
 ): Promise<Result<void, MongoDbError | AssignmentError>> => {
-  const gamesForStartTimes = _.groupBy(games, (game) =>
+  const gamesForStartTimes = groupBy(games, (game) =>
     dayjs(game.startTime).toISOString(),
   );
 
@@ -57,7 +57,7 @@ export const updateWithAssign = async (
     (result) => result.enteredGame.gameDetails,
   );
 
-  const groupedSignups = _.countBy(signedGames, "gameId");
+  const groupedSignups = countBy(signedGames, "gameId");
 
   const gamePopularityUpdates = games
     .map((game) => ({

--- a/server/src/features/game/gameController.test.ts
+++ b/server/src/features/game/gameController.test.ts
@@ -2,7 +2,7 @@ import { Server } from "http";
 import request from "supertest";
 import { faker } from "@faker-js/faker";
 import dayjs from "dayjs";
-import _ from "lodash";
+import { sortBy } from "lodash-es";
 import { expect, test, vi, afterEach, beforeEach, describe } from "vitest";
 import { startServer, closeServer } from "server/utils/server";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
@@ -104,7 +104,7 @@ describe(`GET ${ApiEndpoint.GAMES}`, () => {
     const response = await request(server).get(ApiEndpoint.GAMES);
     expect(response.status).toEqual(200);
 
-    const sortedGames = _.sortBy(response.body.games, "title");
+    const sortedGames = sortBy(response.body.games, "title");
     expect(sortedGames[0].users[0].signupMessage).toEqual(publicMessage);
     expect(sortedGames[1].users[0].signupMessage).toEqual("");
   });
@@ -204,7 +204,7 @@ describe(`POST ${ApiEndpoint.GAMES} Ropecon`, () => {
     const games = unsafelyUnwrapResult(gamesResult);
 
     expect(games.length).toEqual(2);
-    const sortedGames = _.sortBy(games, "title");
+    const sortedGames = sortBy(games, "title");
     expect(sortedGames[0].title).toEqual(testGame.title);
     expect(sortedGames[1].title).toEqual(testGame2.title);
   });
@@ -228,7 +228,7 @@ describe(`POST ${ApiEndpoint.GAMES} Ropecon`, () => {
     const games = unsafelyUnwrapResult(gamesResult);
 
     expect(games.length).toEqual(2);
-    const sortedGames = _.sortBy(games, "title");
+    const sortedGames = sortBy(games, "title");
     expect(sortedGames[0].title).toEqual(testGame.title);
     expect(sortedGames[1].title).toEqual(testGame2.title);
   });
@@ -518,7 +518,7 @@ describe(`POST ${ApiEndpoint.GAMES} Tracon Hitpoint`, () => {
     const games = unsafelyUnwrapResult(gamesResult);
 
     expect(games.length).toEqual(2);
-    const sortedGames = _.sortBy(games, "title");
+    const sortedGames = sortBy(games, "title");
     expect(sortedGames[0].title).toEqual(testGame.title);
     expect(sortedGames[1].title).toEqual(testGame2.title);
   });
@@ -542,7 +542,7 @@ describe(`POST ${ApiEndpoint.GAMES} Tracon Hitpoint`, () => {
     const games = unsafelyUnwrapResult(gamesResult);
 
     expect(games.length).toEqual(2);
-    const sortedGames = _.sortBy(games, "title");
+    const sortedGames = sortBy(games, "title");
     expect(sortedGames[0].title).toEqual(testGame.title);
     expect(sortedGames[1].title).toEqual(testGame2.title);
   });

--- a/server/src/features/game/gameUtils.ts
+++ b/server/src/features/game/gameUtils.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { differenceBy } from "lodash-es";
 import dayjs, { Dayjs } from "dayjs";
 import { findGames, removeGames } from "server/features/game/gameRepository";
 import { GameDoc } from "server/types/gameTypes";
@@ -34,7 +34,7 @@ export const removeDeletedGames = async (
   }
 
   const currentGames = unwrapResult(currentGamesResult);
-  const deletedGames = _.differenceBy(currentGames, updatedGames, "gameId");
+  const deletedGames = differenceBy(currentGames, updatedGames, "gameId");
 
   if (deletedGames.length > 0) {
     const deletedGameIds = deletedGames.map(

--- a/server/src/features/game/utils/getGamesFromKompassiHitpoint.ts
+++ b/server/src/features/game/utils/getGamesFromKompassiHitpoint.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import { ZodError } from "zod";
 import axios from "axios";
-import _ from "lodash";
+import { uniq } from "lodash-es";
 import { logger } from "server/utils/logger";
 import { config } from "shared/config";
 import {
@@ -117,9 +117,7 @@ const checkUnknownKeys = (programItems: KompassiGameHitpoint[]): void => {
     logger.error(
       "%s",
       new Error(
-        `Found unknown keys for program items: ${_.uniq(unknownKeys).join(
-          " ",
-        )}`,
+        `Found unknown keys for program items: ${uniq(unknownKeys).join(" ")}`,
       ),
     );
   }

--- a/server/src/features/game/utils/getGamesFromKompassiRopecon.ts
+++ b/server/src/features/game/utils/getGamesFromKompassiRopecon.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import { ZodError } from "zod";
 import axios from "axios";
-import _ from "lodash";
+import { uniq } from "lodash-es";
 import { logger } from "server/utils/logger";
 import { config } from "shared/config";
 import {
@@ -119,9 +119,7 @@ const checkUnknownKeys = (programItems: KompassiGameRopecon[]): void => {
     logger.error(
       "%s",
       new Error(
-        `Found unknown keys for program items: ${_.uniq(unknownKeys).join(
-          " ",
-        )}`,
+        `Found unknown keys for program items: ${uniq(unknownKeys).join(" ")}`,
       ),
     );
   }

--- a/server/src/features/player-assignment/padg/padgAssignPlayers.ts
+++ b/server/src/features/player-assignment/padg/padgAssignPlayers.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { uniq } from "lodash-es";
 import { User } from "shared/types/models/user";
 import { Game } from "shared/types/models/game";
 import {
@@ -72,7 +72,7 @@ export const padgAssignPlayers = (
 
   const assignmentResult = unwrapResult(assignmentResultResult);
 
-  const selectedUniqueGames = _.uniq(
+  const selectedUniqueGames = uniq(
     assignmentResult.results.map(
       (result) => result.enteredGame.gameDetails.gameId,
     ),

--- a/server/src/features/player-assignment/padg/utils/assignPadg.ts
+++ b/server/src/features/player-assignment/padg/utils/assignPadg.ts
@@ -1,5 +1,5 @@
 import eventassigner from "eventassigner-js";
-import _ from "lodash";
+import { cloneDeep, sortBy } from "lodash-es";
 import {
   PadgInput,
   ListItem,
@@ -25,7 +25,7 @@ export const assignPadg = (
   let finalAssignResults: PadgRandomAssignResults = [];
 
   for (let i = 0; i < PADG_ASSIGNMENT_ROUNDS; i++) {
-    const eventsCopy = _.cloneDeep(events);
+    const eventsCopy = cloneDeep(events);
 
     const input: PadgInput = {
       groups,
@@ -58,9 +58,9 @@ export const assignPadg = (
 const sortList = (list: ListItem[], i: number): ListItem[] => {
   switch (i) {
     case 0:
-      return _.sortBy(list, "gain");
+      return sortBy(list, "gain");
     case 1:
-      return _.sortBy(list, "size");
+      return sortBy(list, "size");
     default:
       return list.sort((_a, _b) => 0.5 - Math.random());
   }

--- a/server/src/features/player-assignment/random/randomAssignPlayers.ts
+++ b/server/src/features/player-assignment/random/randomAssignPlayers.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { uniq } from "lodash-es";
 import { logger } from "server/utils/logger";
 import { getStartingGames } from "server/features/player-assignment/utils/getStartingGames";
 import { runRandomAssignment } from "server/features/player-assignment/random/utils/runRandomAssignment";
@@ -71,7 +71,7 @@ export const randomAssignPlayers = (
 
   const assignmentResult = unwrapResult(assignmentResultResult);
 
-  const selectedUniqueGames = _.uniq(
+  const selectedUniqueGames = uniq(
     assignmentResult.results.map(
       (result) => result.enteredGame.gameDetails.gameId,
     ),

--- a/server/src/features/player-assignment/utils/formatResults.ts
+++ b/server/src/features/player-assignment/utils/formatResults.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { first } from "lodash-es";
 import { PadgRandomAssignResults } from "server/types/padgRandomAssignTypes";
 import { logger } from "server/utils/logger";
 import { AssignmentError } from "shared/types/api/errors";
@@ -16,7 +16,7 @@ export const formatResults = (
 ): Result<readonly AssignmentResult[], AssignmentError> => {
   const selectedPlayers = playerGroups
     .filter((playerGroup) => {
-      const firstMember = _.first(playerGroup);
+      const firstMember = first(playerGroup);
 
       if (!firstMember) {
         logger.error(

--- a/server/src/features/player-assignment/utils/getGroups.ts
+++ b/server/src/features/player-assignment/utils/getGroups.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import _ from "lodash";
+import { first, sortBy } from "lodash-es";
 import { Group } from "server/types/padgRandomAssignTypes";
 import { logger } from "server/utils/logger";
 import { AssignmentError } from "shared/types/api/errors";
@@ -18,7 +18,7 @@ export const getGroups = (
   startTime: string,
 ): Result<Group[], AssignmentError> => {
   const results = playerGroups.map((playerGroup) => {
-    const firstMember = _.first(playerGroup);
+    const firstMember = first(playerGroup);
     if (!firstMember) {
       logger.error("%s", new Error("Padg assign: error getting first member"));
       return makeErrorResult(AssignmentError.UNKNOWN_ERROR);
@@ -29,7 +29,7 @@ export const getGroups = (
         dayjs(signedGame.time).toISOString() === dayjs(startTime).toISOString(),
     );
 
-    const sortedSignedGames = _.sortBy(
+    const sortedSignedGames = sortBy(
       signedGamesForStartTime,
       (signedGame) => signedGame.priority,
     );

--- a/server/src/features/player-assignment/utils/getList.ts
+++ b/server/src/features/player-assignment/utils/getList.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { first } from "lodash-es";
 import dayjs from "dayjs";
 import { ListItem } from "server/types/padgRandomAssignTypes";
 import { getAssignmentBonus } from "server/features/player-assignment/utils/getAssignmentBonus";
@@ -21,7 +21,7 @@ export const getList = (
   signups: readonly Signup[],
 ): Result<ListItem[], AssignmentError> => {
   const results = playerGroups.flatMap((playerGroup) => {
-    const firstMember = _.first(playerGroup);
+    const firstMember = first(playerGroup);
     if (!firstMember) {
       logger.error(
         "%s",

--- a/server/src/features/player-assignment/utils/getPlayerGroups.ts
+++ b/server/src/features/player-assignment/utils/getPlayerGroups.ts
@@ -1,10 +1,10 @@
-import _ from "lodash";
+import { groupBy } from "lodash-es";
 import { User } from "shared/types/models/user";
 
 export const getPlayerGroups = (
   players: readonly User[],
 ): readonly User[][] => {
-  const groupedUsers = _.groupBy(players, "groupCode");
+  const groupedUsers = groupBy(players, "groupCode");
 
   const playersArray = [] as User[][];
   for (const [key, value] of Object.entries(groupedUsers)) {

--- a/server/src/features/signup/signupRepository.ts
+++ b/server/src/features/signup/signupRepository.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import _ from "lodash";
+import { groupBy, shuffle } from "lodash-es";
 import { ObjectId } from "mongoose";
 import { findGameById, findGames } from "server/features/game/gameRepository";
 import { Signup, UserSignup } from "server/features/signup/signupTypes";
@@ -218,7 +218,7 @@ export const saveSignups = async (
   }
   const games = unwrapResult(gamesResult);
 
-  const signupsByProgramItems = _.groupBy(
+  const signupsByProgramItems = groupBy(
     signupsRequests,
     (signup) => signup.enteredGameId,
   );
@@ -240,7 +240,7 @@ export const saveSignups = async (
             `Too many signups passed to saveSignups for program item ${game.gameId} - maxAttendance: ${game.maxAttendance}, signups: ${signups.length}`,
           ),
         );
-        const shuffledSignups = _.shuffle(signups);
+        const shuffledSignups = shuffle(signups);
         finalSignups = shuffledSignups.slice(0, game.maxAttendance);
         droppedSignups.push(
           ...shuffledSignups.slice(game.maxAttendance, shuffledSignups.length),

--- a/server/src/features/statistics/fixer-helpers/formatFeedbacks.ts
+++ b/server/src/features/statistics/fixer-helpers/formatFeedbacks.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import _ from "lodash";
+import { groupBy } from "lodash-es";
 import dayjs from "dayjs";
 import { z } from "zod";
 import { logger } from "server/utils/logger";
@@ -58,7 +58,7 @@ export const formatFeedbacks = (year: number, event: string): void => {
 
   logger.info(`Formatted ${formattedFeedbacks.length} feedbacks`);
 
-  const groupedByProgramTypeFeedbacks = _.groupBy(
+  const groupedByProgramTypeFeedbacks = groupBy(
     formattedFeedbacks,
     (feedback) => feedback.programType,
   );
@@ -70,7 +70,7 @@ export const formatFeedbacks = (year: number, event: string): void => {
       );
 
       // @ts-expect-error: FIXME
-      const groupedByOrganizerFeedbacks: Record<string, Message[]> = _.groupBy(
+      const groupedByOrganizerFeedbacks: Record<string, Message[]> = groupBy(
         programTypeFeedbacks,
         (feedback) => feedback.organizer,
       );

--- a/server/src/features/statistics/fixer-helpers/gameIdFix.ts
+++ b/server/src/features/statistics/fixer-helpers/gameIdFix.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import _ from "lodash";
+import { isEqual } from "lodash-es";
 import { logger } from "server/utils/logger";
 import { User } from "shared/types/models/user";
 import { GameDoc } from "server/types/gameTypes";
@@ -102,7 +102,7 @@ export const gameIdFix = async (year: number, event: string): Promise<void> => {
   results.map((result) => {
     result.results.map((userResult) => {
       const matchingGame = games.find((game) => {
-        return _.isEqual(game._id, userResult.enteredGame.gameDetails);
+        return isEqual(game._id, userResult.enteredGame.gameDetails);
       });
 
       if (!matchingGame) {
@@ -129,7 +129,7 @@ export const gameIdFix = async (year: number, event: string): Promise<void> => {
 
   signups.map((signup) => {
     games.map((game) => {
-      if (_.isEqual(game._id, signup.game)) {
+      if (isEqual(game._id, signup.game)) {
         // @ts-expect-error: We don't want whole game details
         signup.game = { gameId: game.gameId };
       }
@@ -141,7 +141,7 @@ export const gameIdFix = async (year: number, event: string): Promise<void> => {
   settings.map((setting) => {
     games.map((game) => {
       setting.hiddenGames.map((hiddenGame) => {
-        if (_.isEqual(game._id, hiddenGame)) {
+        if (isEqual(game._id, hiddenGame)) {
           // @ts-expect-error: We don't want whole game details
           tempHiddenGames.push({ gameId: game.gameId });
         }

--- a/server/src/features/statistics/statistics-helpers/gameDataHelpers.ts
+++ b/server/src/features/statistics/statistics-helpers/gameDataHelpers.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import _ from "lodash";
+import { countBy } from "lodash-es";
 import { logger } from "server/utils/logger";
 import { Game } from "shared/types/models/game";
 import { SelectedGame, User } from "shared/types/models/user";
@@ -11,7 +11,7 @@ import { TIMEZONE } from "shared/utils/initializeDayjs";
 export const getGamesByStartTime = (
   games: readonly Game[],
 ): StringNumberObject => {
-  const gamesByTime = _.countBy(games, "startTime");
+  const gamesByTime = countBy(games, "startTime");
 
   logger.info(`Number of games for each start time: \n`, gamesByTime);
   return gamesByTime;
@@ -21,7 +21,7 @@ const getUsersByGames = (_users: readonly User[]): StringNumberObject => {
   // TODO: Update to use signup collection
   // const enteredGames = users.flatMap((user) => user.enteredGames);
   const enteredGames: SelectedGame[] = [];
-  const usersByGames = _.countBy(enteredGames, "gameDetails.gameId");
+  const usersByGames = countBy(enteredGames, "gameDetails.gameId");
   return usersByGames;
 };
 

--- a/server/src/features/statistics/statistics-helpers/userDataHelpers.ts
+++ b/server/src/features/statistics/statistics-helpers/userDataHelpers.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { countBy } from "lodash-es";
 import { logger } from "server/utils/logger";
 import { User } from "shared/types/models/user";
 import { StringNumberObject } from "server/types/commonTypes";
@@ -52,7 +52,7 @@ export const getUsersWithoutSignups = (
 export const getUsersSignupCount = (users: readonly User[]): void => {
   const userSignupCounts: StringNumberObject[] = [];
   users.forEach((user) => {
-    const signedGames = _.countBy(user.signedGames, "time");
+    const signedGames = countBy(user.signedGames, "time");
     userSignupCounts.push(signedGames);
   });
 
@@ -87,7 +87,7 @@ export const getUsersWithAllGames = (_users: readonly User[]): void => {
   let counter = 0;
 
   users.forEach((user) => {
-    const signedGamesByTime = _.countBy(user.signedGames, "time");
+    const signedGamesByTime = countBy(user.signedGames, "time");
 
     if (Object.keys(signedGamesByTime).length === user.enteredGames.length) {
       counter++;

--- a/server/src/features/statistics/statsUtil.ts
+++ b/server/src/features/statistics/statsUtil.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import _ from "lodash";
+import { size } from "lodash-es";
 import prettier from "prettier";
 import { config } from "shared/config";
 import { logger } from "server/utils/logger";
@@ -114,5 +114,5 @@ const getDataLength = <T>(data: T[] | Object): number => {
   if (Array.isArray(data)) {
     return data.length;
   }
-  return _.size(data);
+  return size(data);
 };

--- a/server/src/features/user/event-log/eventLogRepository.ts
+++ b/server/src/features/user/event-log/eventLogRepository.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import _ from "lodash";
+import { uniq } from "lodash-es";
 import { MongoDbError } from "shared/types/api/errors";
 import {
   Result,
@@ -45,13 +45,11 @@ export const addEventLogItems = async (
   try {
     // @ts-expect-error: Types don't work with $addToSet
     await UserModel.bulkWrite(bulkOps);
-    logger.info(
-      `MongoDB: Action log item added for users ${_.uniq(usernames)}`,
-    );
+    logger.info(`MongoDB: Action log item added for users ${uniq(usernames)}`);
     return makeSuccessResult(undefined);
   } catch (error) {
     logger.error(
-      `MongoDB: Error adding event log item for users ${_.uniq(usernames)}: %s`,
+      `MongoDB: Error adding event log item for users ${uniq(usernames)}: %s`,
       error,
     );
     return makeErrorResult(MongoDbError.UNKNOWN_ERROR);

--- a/server/src/features/user/signed-game/signedGameService.ts
+++ b/server/src/features/user/signed-game/signedGameService.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { groupBy, uniq } from "lodash-es";
 import dayjs from "dayjs";
 import {
   PostSignedGamesError,
@@ -39,11 +39,11 @@ export const storeSignedGames = async (
   }
 
   // Check for duplicate priorities, ie. some kind of error
-  const gamesByTimeslot = _.groupBy(selectedGames, (game) => game.time);
+  const gamesByTimeslot = groupBy(selectedGames, (game) => game.time);
 
   for (const [, games] of Object.entries(gamesByTimeslot)) {
     const priorities = games.map((selectedGame) => selectedGame.priority);
-    const uniqPriorities = _.uniq(priorities);
+    const uniqPriorities = uniq(priorities);
 
     if (priorities.length !== uniqPriorities.length) {
       return {

--- a/server/src/test/test-data-generation/generators/createEventLogItems.ts
+++ b/server/src/test/test-data-generation/generators/createEventLogItems.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import _ from "lodash";
+import { sampleSize } from "lodash-es";
 import { findGames } from "server/features/game/gameRepository";
 import { addEventLogItems } from "server/features/user/event-log/eventLogRepository";
 import { findUsers } from "server/features/user/userRepository";
@@ -22,7 +22,7 @@ export const createEventLogItems = async (): Promise<void> => {
   );
 
   const eventLogUpdates = users.flatMap((user) => {
-    const randomGames = _.sampleSize(twoPhaseSignups, 5);
+    const randomGames = sampleSize(twoPhaseSignups, 5);
 
     return randomGames.map((randomGame, index) => ({
       username: user.username,

--- a/server/src/test/test-data-generation/generators/createGames.ts
+++ b/server/src/test/test-data-generation/generators/createGames.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import dayjs from "dayjs";
-import _ from "lodash";
+import { sample, sampleSize } from "lodash-es";
 import { logger } from "server/utils/logger";
 import { kompassiGameMapperRopecon } from "server/utils/kompassiGameMapperRopecon";
 import { saveGames } from "server/features/game/gameRepository";
@@ -60,12 +60,12 @@ const getProgramType = (
 ): KompassiProgramTypeRopecon => {
   if (programType === KompassiProgramTypeRopecon.TOURNAMENT_BOARD_GAME) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- We know tournamentProgramTypes is valid array
-    return _.sample(tournamentProgramTypesRopecon)!;
+    return sample(tournamentProgramTypesRopecon)!;
   }
 
   if (programType === KompassiProgramTypeRopecon.WORKSHOP_MINIATURE) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- We know tournamentProgramTypes is valid array
-    return _.sample(workshopProgramTypesRopecon)!;
+    return sample(workshopProgramTypesRopecon)!;
   }
 
   return programType;
@@ -108,9 +108,9 @@ export const createGames = async (
           min_players: getMinPlayers(programType),
           max_players: getMaxPlayers(programType),
           identifier: faker.number.int(GAME_ID_MAX).toString(),
-          tags: _.sampleSize(Object.values(KompassiTagRopecon), 3),
-          genres: _.sampleSize(Object.values(KompassiGenreRopecon), 2),
-          styles: _.sampleSize(Object.values(KompassiGameStyleRopecon), 2),
+          tags: sampleSize(Object.values(KompassiTagRopecon), 3),
+          genres: sampleSize(Object.values(KompassiGenreRopecon), 2),
+          styles: sampleSize(Object.values(KompassiGameStyleRopecon), 2),
           short_blurb: faker.lorem.sentence(),
           revolving_door: Math.random() < 0.5,
           other_author: "Other author",

--- a/server/src/test/test-data-generation/generators/createSignedGames.ts
+++ b/server/src/test/test-data-generation/generators/createSignedGames.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import dayjs from "dayjs";
-import _ from "lodash";
+import { groupBy } from "lodash-es";
 import { logger } from "server/utils/logger";
 import { updateGamePopularity } from "server/features/game-popularity/updateGamePopularity";
 import { Game } from "shared/types/models/game";
@@ -24,7 +24,7 @@ export const createSignedGames = async (): Promise<void> => {
   logger.info(`Signup: ${games.length} games`);
   logger.info(`Signup: ${users.length} users`);
 
-  const groupedUsers = _.groupBy(users, "groupCode");
+  const groupedUsers = groupBy(users, "groupCode");
 
   for (const [groupCode, groupMembers] of Object.entries(groupedUsers)) {
     // Individual users

--- a/server/src/test/test-data-generation/generators/createSignups.ts
+++ b/server/src/test/test-data-generation/generators/createSignups.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import _ from "lodash";
+import { groupBy } from "lodash-es";
 import { logger } from "server/utils/logger";
 import { findUsers } from "server/features/user/userRepository";
 import { findGames } from "server/features/game/gameRepository";
@@ -31,7 +31,7 @@ export const createSignups = async (): Promise<void> => {
 
   const shuffledGames = shuffleArray(games);
 
-  const gamesByProgramType = _.groupBy(shuffledGames, "programType");
+  const gamesByProgramType = groupBy(shuffledGames, "programType");
 
   const promises = Object.entries(gamesByProgramType).flatMap(
     ([_programType, gamesForProgamType]) => {

--- a/server/src/utils/kompassiGameMapperHitpoint.ts
+++ b/server/src/utils/kompassiGameMapperHitpoint.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import _ from "lodash";
+import { uniq } from "lodash-es";
 import { Game, Language, ProgramType, Tag } from "shared/types/models/game";
 import { exhaustiveSwitchGuard } from "shared/utils/exhaustiveSwitchGuard";
 import {
@@ -76,7 +76,7 @@ const mapTags = (kompassiGame: KompassiGameHitpoint): Tag[] => {
     tags.push(Tag.INTENDED_FOR_EXPERIENCED_PARTICIPANTS);
   }
 
-  return _.uniq(tags);
+  return uniq(tags);
 };
 
 const mapLanguage = (kompassiGame: KompassiGameHitpoint) => {

--- a/server/src/utils/kompassiGameMapperRopecon.ts
+++ b/server/src/utils/kompassiGameMapperRopecon.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { uniq } from "lodash-es";
 import dayjs from "dayjs";
 import {
   AccessibilityValue,
@@ -200,7 +200,7 @@ const mapTags = (kompassiGame: KompassiGameRopecon): Tag[] => {
     tags.push(Tag.CELEBRATORY_YEAR);
   }
 
-  return _.uniq(tags);
+  return uniq(tags);
 };
 
 const mapGenres = (kompassiGame: KompassiGameRopecon): Genre[] => {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -3,11 +3,6 @@
   "compilerOptions": {
     "outDir": "lib"
   },
-  "ts-node": {
-    "transpileOnly": true,
-    "require": ["tsconfig-paths/register"],
-    "files": true
-  },
   "include": ["**/*.js", "**/*.ts", "./.eslintrc.js", "vitest.config.mts"],
   "exclude": ["./node_modules", "./lib", "./coverage", "./front"]
 }

--- a/shared/types/models/kompassiGame/kompassiGameRopecon.ts
+++ b/shared/types/models/kompassiGame/kompassiGameRopecon.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import _ from "lodash";
+import { partition } from "lodash-es";
 import { logger } from "server/utils/logger";
 
 export enum KompassiProgramTypeRopecon {
@@ -129,7 +129,7 @@ export const KompassiGameSchemaRopecon = z.object({
     if (!ctx.input || !Array.isArray(ctx.input)) {
       return [];
     }
-    const [valid, invalid] = _.partition(ctx.input, (tag) =>
+    const [valid, invalid] = partition(ctx.input, (tag) =>
       Object.values(KompassiTagRopecon).includes(tag),
     );
     logger.error("%s", new Error(`Invalid tags: ${JSON.stringify(invalid)}`));
@@ -141,7 +141,7 @@ export const KompassiGameSchemaRopecon = z.object({
     if (!ctx.input || !Array.isArray(ctx.input)) {
       return [];
     }
-    const [valid, invalid] = _.partition(ctx.input, (genre) =>
+    const [valid, invalid] = partition(ctx.input, (genre) =>
       Object.values(KompassiGenreRopecon).includes(genre),
     );
     logger.error("%s", new Error(`Invalid genres: ${JSON.stringify(invalid)}`));
@@ -153,7 +153,7 @@ export const KompassiGameSchemaRopecon = z.object({
     if (!ctx.input || !Array.isArray(ctx.input)) {
       return [];
     }
-    const [valid, invalid] = _.partition(ctx.input, (style) =>
+    const [valid, invalid] = partition(ctx.input, (style) =>
       Object.values(KompassiGameStyleRopecon).includes(style),
     );
     logger.error("%s", new Error(`Invalid styles: ${JSON.stringify(invalid)}`));

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,7 +224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.0.0-beta.49, @babel/helper-module-imports@npm:^7.21.4, @babel/helper-module-imports@npm:^7.22.15":
+"@babel/helper-module-imports@npm:^7.21.4, @babel/helper-module-imports@npm:^7.22.15":
   version: 7.22.15
   resolution: "@babel/helper-module-imports@npm:7.22.15"
   dependencies:
@@ -317,14 +317,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-string-parser@npm:^7.19.4, @babel/helper-string-parser@npm:^7.23.4":
+"@babel/helper-string-parser@npm:^7.23.4":
   version: 7.23.4
   resolution: "@babel/helper-string-parser@npm:7.23.4"
   checksum: f348d5637ad70b6b54b026d6544bd9040f78d24e7ec245a0fc42293968181f6ae9879c22d89744730d246ce8ec53588f716f102addd4df8bbc79b73ea10004ac
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.19.1, @babel/helper-validator-identifier@npm:^7.22.20":
+"@babel/helper-validator-identifier@npm:^7.22.20":
   version: 7.22.20
   resolution: "@babel/helper-validator-identifier@npm:7.22.20"
   checksum: dcad63db345fb110e032de46c3688384b0008a42a4845180ce7cd62b1a9c0507a1bed727c4d1060ed1a03ae57b4d918570259f81724aaac1a5b776056f37504e
@@ -1501,17 +1501,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:7.20.7":
-  version: 7.20.7
-  resolution: "@babel/types@npm:7.20.7"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.19.4"
-    "@babel/helper-validator-identifier": "npm:^7.19.1"
-    to-fast-properties: "npm:^2.0.0"
-  checksum: df0061f306bd95389604075ba5a88e984a801635c70c77b3b6ae8ab44675064b9ef4088c6c78dbf786a28efc662ad37f9c09f8658ba44c12cb8dd6f450a8bde7
-  languageName: node
-  linkType: hard
-
 "@babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.23.3, @babel/types@npm:^7.23.4, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.23.4
   resolution: "@babel/types@npm:7.23.4"
@@ -2657,7 +2646,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:4.14.202":
+"@types/lodash-es@npm:4.17.12":
+  version: 4.17.12
+  resolution: "@types/lodash-es@npm:4.17.12"
+  dependencies:
+    "@types/lodash": "npm:*"
+  checksum: 5d12d2cede07f07ab067541371ed1b838a33edb3c35cb81b73284e93c6fd0c4bbeaefee984e69294bffb53f62d7272c5d679fdba8e595ff71e11d00f2601dde0
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
   version: 4.14.202
   resolution: "@types/lodash@npm:4.14.202"
   checksum: 6064d43c8f454170841bd67c8266cc9069d9e570a72ca63f06bceb484cb4a3ee60c9c1f305c1b9e3a87826049fd41124b8ef265c4dd08b00f6766609c7fe9973
@@ -3970,19 +3968,6 @@ __metadata:
     "@babel/core": ^7.12.0
     webpack: ">=5"
   checksum: e3fc3c9e02bd908b37e8e8cd4f3d7280cf6ac45e33fc203aedbb615135a0fecc33bf92573b71a166a827af029d302c0b060354985cd91d510320bd70a2f949eb
-  languageName: node
-  linkType: hard
-
-"babel-plugin-lodash@npm:3.3.4":
-  version: 3.3.4
-  resolution: "babel-plugin-lodash@npm:3.3.4"
-  dependencies:
-    "@babel/helper-module-imports": "npm:^7.0.0-beta.49"
-    "@babel/types": "npm:^7.0.0-beta.49"
-    glob: "npm:^7.1.1"
-    lodash: "npm:^4.17.10"
-    require-package-name: "npm:^2.0.1"
-  checksum: 1a1db624f70c1e9badd3ca112bc6819157e75768aab949c424cfabe562765d7f22cf93e5e088e820d5d5b1da7b2bd9d045cb54a5790616b65da1f84eda2ecc08
   languageName: node
   linkType: hard
 
@@ -7077,7 +7062,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.3, glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.2.0":
+"glob@npm:^7.0.3, glob@npm:^7.1.3, glob@npm:^7.2.0":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -8632,12 +8617,11 @@ __metadata:
     "@babel/preset-env": "npm:7.23.3"
     "@babel/preset-react": "npm:7.23.3"
     "@babel/preset-typescript": "npm:7.23.3"
-    "@types/lodash": "npm:4.14.202"
+    "@types/lodash-es": "npm:4.17.12"
     "@typescript-eslint/eslint-plugin": "npm:6.12.0"
     "@typescript-eslint/parser": "npm:6.12.0"
     "@yarnpkg/types": "npm:4.0.0"
     axios: "npm:1.6.2"
-    babel-plugin-lodash: "npm:3.3.4"
     babel-plugin-module-resolver: "npm:5.0.0"
     concurrently: "npm:8.2.2"
     cross-env: "npm:7.0.3"
@@ -8662,7 +8646,7 @@ __metadata:
     husky: "npm:8.0.3"
     is-ci: "npm:3.0.1"
     lint-staged: "npm:15.1.0"
-    lodash: "npm:4.17.21"
+    lodash-es: "npm:4.17.21"
     ncp: "npm:2.0.0"
     prettier: "npm:3.1.0"
     rimraf: "npm:5.0.5"
@@ -8873,6 +8857,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash-es@npm:4.17.21":
+  version: 4.17.21
+  resolution: "lodash-es@npm:4.17.21"
+  checksum: fb407355f7e6cd523a9383e76e6b455321f0f153a6c9625e21a8827d10c54c2a2341bd2ae8d034358b60e07325e1330c14c224ff582d04612a46a4f0479ff2f2
+  languageName: node
+  linkType: hard
+
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
@@ -8950,7 +8941,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4, lodash@npm:^4.17.10, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
+"lodash@npm:^4, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
@@ -11639,13 +11630,6 @@ __metadata:
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
   checksum: aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
-  languageName: node
-  linkType: hard
-
-"require-package-name@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "require-package-name@npm:2.0.1"
-  checksum: 2da87caecdd2157489deaf8add246696dc9cbcebd89ef49b062ad1183594b979f96f8194d4b0f5447a92ad72d39b9fae2df38ec5b9ecef9c7c0157af38eeecbc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1463,7 +1463,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.23.4
   resolution: "@babel/runtime@npm:7.23.4"
   dependencies:
@@ -1516,15 +1516,6 @@ __metadata:
   version: 1.6.0
   resolution: "@colors/colors@npm:1.6.0"
   checksum: 9328a0778a5b0db243af54455b79a69e3fb21122d6c15ef9e9fcc94881d8d17352d8b2b2590f9bdd46fac5c2d6c1636dcfc14358a20c70e22daf89e1a759b629
-  languageName: node
-  linkType: hard
-
-"@cspotcode/source-map-support@npm:^0.8.0":
-  version: 0.8.1
-  resolution: "@cspotcode/source-map-support@npm:0.8.1"
-  dependencies:
-    "@jridgewell/trace-mapping": "npm:0.3.9"
-  checksum: 05c5368c13b662ee4c122c7bfbe5dc0b613416672a829f3e78bc49a357a197e0218d6e74e7c66cfcd04e15a179acab080bd3c69658c9fbefd0e1ccd950a07fc6
   languageName: node
   linkType: hard
 
@@ -1604,10 +1595,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/android-arm64@npm:0.18.20"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/android-arm64@npm:0.19.7"
   conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/android-arm@npm:0.18.20"
+  conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
@@ -1618,10 +1623,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/android-x64@npm:0.18.20"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-x64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/android-x64@npm:0.19.7"
   conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/darwin-arm64@npm:0.18.20"
+  conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -1632,10 +1651,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/darwin-x64@npm:0.18.20"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-x64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/darwin-x64@npm:0.19.7"
   conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/freebsd-arm64@npm:0.18.20"
+  conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -1646,10 +1679,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/freebsd-x64@npm:0.18.20"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-x64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/freebsd-x64@npm:0.19.7"
   conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-arm64@npm:0.18.20"
+  conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -1660,10 +1707,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-arm@npm:0.18.20"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/linux-arm@npm:0.19.7"
   conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-ia32@npm:0.18.20"
+  conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
@@ -1674,10 +1735,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-loong64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-loong64@npm:0.18.20"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-loong64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/linux-loong64@npm:0.19.7"
   conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-mips64el@npm:0.18.20"
+  conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
@@ -1688,10 +1763,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ppc64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-ppc64@npm:0.18.20"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ppc64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/linux-ppc64@npm:0.19.7"
   conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-riscv64@npm:0.18.20"
+  conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
@@ -1702,10 +1791,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-s390x@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-s390x@npm:0.18.20"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-s390x@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/linux-s390x@npm:0.19.7"
   conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/linux-x64@npm:0.18.20"
+  conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1716,10 +1819,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/netbsd-x64@npm:0.18.20"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-x64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/netbsd-x64@npm:0.19.7"
   conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/openbsd-x64@npm:0.18.20"
+  conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1730,10 +1847,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/sunos-x64@npm:0.18.20"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/sunos-x64@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/sunos-x64@npm:0.19.7"
   conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/win32-arm64@npm:0.18.20"
+  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -1744,10 +1875,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/win32-ia32@npm:0.18.20"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.19.7":
   version: 0.19.7
   resolution: "@esbuild/win32-ia32@npm:0.19.7"
   conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.18.20":
+  version: 0.18.20
+  resolution: "@esbuild/win32-x64@npm:0.18.20"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1912,7 +2057,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.0.3, @jridgewell/resolve-uri@npm:^3.1.0":
+"@jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.1
   resolution: "@jridgewell/resolve-uri@npm:3.1.1"
   checksum: 0dbc9e29bc640bbbdc5b9876d2859c69042bfcf1423c1e6421bcca53e826660bff4e41c7d4bcb8dbea696404231a6f902f76ba41835d049e20f2dd6cffb713bf
@@ -1940,16 +2085,6 @@ __metadata:
   version: 1.4.15
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
   checksum: 0c6b5ae663087558039052a626d2d7ed5208da36cfd707dcc5cea4a07cfc918248403dcb5989a8f7afaf245ce0573b7cc6fd94c4a30453bd10e44d9363940ba5
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:0.3.9":
-  version: 0.3.9
-  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
-  dependencies:
-    "@jridgewell/resolve-uri": "npm:^3.0.3"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
-  checksum: fa425b606d7c7ee5bfa6a31a7b050dd5814b4082f318e0e4190f991902181b4330f43f4805db1dd4f2433fd0ed9cc7a7b9c2683f1deeab1df1b0a98b1e24055b
   languageName: node
   linkType: hard
 
@@ -2383,34 +2518,6 @@ __metadata:
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
   checksum: 073bfa548026b1ebaf1659eb8961e526be22fa77139b10d60e712f46d2f0f05f4e6c8bec62a087d41088ee9e29faa7f54838568e475ab2f776171003c3920858
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node10@npm:^1.0.7":
-  version: 1.0.9
-  resolution: "@tsconfig/node10@npm:1.0.9"
-  checksum: c176a2c1e1b16be120c328300ea910df15fb9a5277010116d26818272341a11483c5a80059389d04edacf6fd2d03d4687ad3660870fdd1cc0b7109e160adb220
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node12@npm:^1.0.7":
-  version: 1.0.11
-  resolution: "@tsconfig/node12@npm:1.0.11"
-  checksum: dddca2b553e2bee1308a056705103fc8304e42bb2d2cbd797b84403a223b25c78f2c683ec3e24a095e82cd435387c877239bffcb15a590ba817cd3f6b9a99fd9
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node14@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "@tsconfig/node14@npm:1.0.3"
-  checksum: 67c1316d065fdaa32525bc9449ff82c197c4c19092b9663b23213c8cbbf8d88b6ed6a17898e0cbc2711950fbfaf40388938c1c748a2ee89f7234fc9e7fe2bf44
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node16@npm:^1.0.2":
-  version: 1.0.4
-  resolution: "@tsconfig/node16@npm:1.0.4"
-  checksum: 05f8f2734e266fb1839eb1d57290df1664fe2aa3b0fdd685a9035806daa635f7519bf6d5d9b33f6e69dd545b8c46bd6e2b5c79acb2b1f146e885f7f11a42a5bb
   languageName: node
   linkType: hard
 
@@ -2861,20 +2968,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: b20b7820ee813f22de4f2ce98bdd12c68c930e016a8912b1ed967595ac0d8a4cbbff44f4d486dd97f77f5927e7b5725bdac7472c9ec5b27f53a5a13179f0612f
-  languageName: node
-  linkType: hard
-
-"@types/strip-bom@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@types/strip-bom@npm:3.0.0"
-  checksum: 6638635fb52dc1f7a4aa596445170ffc731f3bea307d25d79709dcce14f80870128a6f0304032863b9d1a86b4b5f45d48bcaf96abe81f42e61f0a3eb18a1b996
-  languageName: node
-  linkType: hard
-
-"@types/strip-json-comments@npm:0.0.30":
-  version: 0.0.30
-  resolution: "@types/strip-json-comments@npm:0.0.30"
-  checksum: 90509e345ac16c79f7aa7d7ef52e388e5be923f3456cf8052d36ee0eb4abc5ec4080c5f010f78cf01f5599546577eb3724256bc698663e86f0fe08a5a3fb7f68
   languageName: node
   linkType: hard
 
@@ -3474,14 +3567,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^8.0.0, acorn-walk@npm:^8.1.1, acorn-walk@npm:^8.2.0":
+"acorn-walk@npm:^8.0.0, acorn-walk@npm:^8.2.0":
   version: 8.3.0
   resolution: "acorn-walk@npm:8.3.0"
   checksum: 24346e595f507b6e704a60d35f3c5e1aa9891d4fb6a3fc3d856503ab718cc26cabb5e3e1ff0ff8da6ec03d60a8226ebdb602805a94f970e7f797ea3b8b09437f
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.0.0, acorn@npm:^8.0.4, acorn@npm:^8.10.0, acorn@npm:^8.4.1, acorn@npm:^8.7.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
+"acorn@npm:^8.0.0, acorn@npm:^8.0.4, acorn@npm:^8.10.0, acorn@npm:^8.7.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
   version: 8.11.2
   resolution: "acorn@npm:8.11.2"
   bin:
@@ -3647,13 +3740,6 @@ __metadata:
     normalize-path: "npm:^3.0.0"
     picomatch: "npm:^2.0.4"
   checksum: 57b06ae984bc32a0d22592c87384cd88fe4511b1dd7581497831c56d41939c8a001b28e7b853e1450f2bf61992dfcaa8ae2d0d161a0a90c4fb631ef07098fbac
-  languageName: node
-  linkType: hard
-
-"arg@npm:^4.1.0":
-  version: 4.1.3
-  resolution: "arg@npm:4.1.3"
-  checksum: 070ff801a9d236a6caa647507bdcc7034530604844d64408149a26b9e87c2f97650055c0f049abd1efc024b334635c01f29e0b632b371ac3f26130f4cf65997a
   languageName: node
   linkType: hard
 
@@ -4388,7 +4474,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.4.2":
+"chalk@npm:^2.4.1, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -4399,7 +4485,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -4446,7 +4532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.4.0, chokidar@npm:^3.5.1, chokidar@npm:^3.5.3":
+"chokidar@npm:^3.4.0, chokidar@npm:^3.5.3":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
@@ -4768,26 +4854,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"concurrently@npm:8.2.2":
-  version: 8.2.2
-  resolution: "concurrently@npm:8.2.2"
-  dependencies:
-    chalk: "npm:^4.1.2"
-    date-fns: "npm:^2.30.0"
-    lodash: "npm:^4.17.21"
-    rxjs: "npm:^7.8.1"
-    shell-quote: "npm:^1.8.1"
-    spawn-command: "npm:0.0.2"
-    supports-color: "npm:^8.1.1"
-    tree-kill: "npm:^1.2.2"
-    yargs: "npm:^17.7.2"
-  bin:
-    conc: dist/bin/concurrently.js
-    concurrently: dist/bin/concurrently.js
-  checksum: 0e9683196fe9c071d944345d21d8f34aa6c0cc50c0dd897e95619f2f1c9eb4871dca851b2569da17888235b7335b4c821ca19deed35bebcd9a131ee5d247f34c
-  languageName: node
-  linkType: hard
-
 "connect-history-api-fallback@npm:^2.0.0":
   version: 2.0.0
   resolution: "connect-history-api-fallback@npm:2.0.0"
@@ -4886,13 +4952,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-require@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "create-require@npm:1.1.1"
-  checksum: 157cbc59b2430ae9a90034a5f3a1b398b6738bf510f713edc4d4e45e169bc514d3d99dd34d8d01ca7ae7830b5b8b537e46ae8f3c8f932371b0875c0151d7ec91
-  languageName: node
-  linkType: hard
-
 "croner@npm:7.0.5":
   version: 7.0.5
   resolution: "croner@npm:7.0.5"
@@ -4909,6 +4968,19 @@ __metadata:
     cross-env: src/bin/cross-env.js
     cross-env-shell: src/bin/cross-env-shell.js
   checksum: f3765c25746c69fcca369655c442c6c886e54ccf3ab8c16847d5ad0e91e2f337d36eedc6599c1227904bf2a228d721e690324446876115bc8e7b32a866735ecf
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^6.0.5":
+  version: 6.0.5
+  resolution: "cross-spawn@npm:6.0.5"
+  dependencies:
+    nice-try: "npm:^1.0.4"
+    path-key: "npm:^2.0.1"
+    semver: "npm:^5.5.0"
+    shebang-command: "npm:^1.2.0"
+    which: "npm:^1.2.9"
+  checksum: e05544722e9d7189b4292c66e42b7abeb21db0d07c91b785f4ae5fefceb1f89e626da2703744657b287e86dcd4af57b54567cef75159957ff7a8a761d9055012
   languageName: node
   linkType: hard
 
@@ -5028,15 +5100,6 @@ __metadata:
     whatwg-mimetype: "npm:^3.0.0"
     whatwg-url: "npm:^12.0.0"
   checksum: 928d9a21db31d3dcee125d514fddfeb88067c348b1225e9d2c6ca55db16e1cbe49bf58c092cae7163de958f415fd5c612c2aef2eef87896e097656fce205d766
-  languageName: node
-  linkType: hard
-
-"date-fns@npm:^2.30.0":
-  version: 2.30.0
-  resolution: "date-fns@npm:2.30.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.21.0"
-  checksum: e4b521fbf22bc8c3db332bbfb7b094fd3e7627de0259a9d17c7551e2d2702608a7307a449206065916538e384f37b181565447ce2637ae09828427aed9cb5581
   languageName: node
   linkType: hard
 
@@ -5290,13 +5353,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:^4.0.1":
-  version: 4.0.2
-  resolution: "diff@npm:4.0.2"
-  checksum: 81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
-  languageName: node
-  linkType: hard
-
 "dir-glob@npm:^3.0.1":
   version: 3.0.1
   resolution: "dir-glob@npm:3.0.1"
@@ -5475,15 +5531,6 @@ __metadata:
     readable-stream: "npm:^3.1.1"
     stream-shift: "npm:^1.0.0"
   checksum: cacd09d8f1c58f92f83e17dffc14ece50415b32753446ed92046236a27a9e73cb914cda495d955ea12e0e615381082a511f20e219f48a06e84675c9d6950675b
-  languageName: node
-  linkType: hard
-
-"dynamic-dedupe@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "dynamic-dedupe@npm:0.3.0"
-  dependencies:
-    xtend: "npm:^4.0.0"
-  checksum: 505a79f05221daaa5b6d4b6dddc30881809a136810acea138bf56e784b15c237077864ae18824b5dfb0f836a321d14cec0b7cec004e6abf31c38a1e9862af22b
   languageName: node
   linkType: hard
 
@@ -5823,6 +5870,83 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: ec72d9523559005cf9d15c9c9295406633a0c38a20b63d76f22de211902d4cfbe1bfc713a19b4125355cbde5cdf80a1702c13f20cdc035fdbe7aa52d706de59c
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:~0.18.20":
+  version: 0.18.20
+  resolution: "esbuild@npm:0.18.20"
+  dependencies:
+    "@esbuild/android-arm": "npm:0.18.20"
+    "@esbuild/android-arm64": "npm:0.18.20"
+    "@esbuild/android-x64": "npm:0.18.20"
+    "@esbuild/darwin-arm64": "npm:0.18.20"
+    "@esbuild/darwin-x64": "npm:0.18.20"
+    "@esbuild/freebsd-arm64": "npm:0.18.20"
+    "@esbuild/freebsd-x64": "npm:0.18.20"
+    "@esbuild/linux-arm": "npm:0.18.20"
+    "@esbuild/linux-arm64": "npm:0.18.20"
+    "@esbuild/linux-ia32": "npm:0.18.20"
+    "@esbuild/linux-loong64": "npm:0.18.20"
+    "@esbuild/linux-mips64el": "npm:0.18.20"
+    "@esbuild/linux-ppc64": "npm:0.18.20"
+    "@esbuild/linux-riscv64": "npm:0.18.20"
+    "@esbuild/linux-s390x": "npm:0.18.20"
+    "@esbuild/linux-x64": "npm:0.18.20"
+    "@esbuild/netbsd-x64": "npm:0.18.20"
+    "@esbuild/openbsd-x64": "npm:0.18.20"
+    "@esbuild/sunos-x64": "npm:0.18.20"
+    "@esbuild/win32-arm64": "npm:0.18.20"
+    "@esbuild/win32-ia32": "npm:0.18.20"
+    "@esbuild/win32-x64": "npm:0.18.20"
+  dependenciesMeta:
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 473b1d92842f50a303cf948a11ebd5f69581cd254d599dd9d62f9989858e0533f64e83b723b5e1398a5b488c0f5fd088795b4235f65ecaf4f007d4b79f04bc88
   languageName: node
   linkType: hard
 
@@ -7013,7 +7137,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:^4.5.0, get-tsconfig@npm:^4.7.0":
+"get-tsconfig@npm:^4.5.0, get-tsconfig@npm:^4.7.0, get-tsconfig@npm:^4.7.2":
   version: 4.7.2
   resolution: "get-tsconfig@npm:4.7.2"
   dependencies:
@@ -8407,6 +8531,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-parse-better-errors@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "json-parse-better-errors@npm:1.0.2"
+  checksum: 2f1287a7c833e397c9ddd361a78638e828fc523038bb3441fd4fc144cfd2c6cd4963ffb9e207e648cf7b692600f1e1e524e965c32df5152120910e4903a47dcb
+  languageName: node
+  linkType: hard
+
 "json-parse-even-better-errors@npm:^2.3.0, json-parse-even-better-errors@npm:^2.3.1":
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
@@ -8446,7 +8577,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.1.1, json5@npm:^2.1.2, json5@npm:^2.2.2, json5@npm:^2.2.3":
+"json5@npm:^2.1.1, json5@npm:^2.1.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -8623,7 +8754,6 @@ __metadata:
     "@yarnpkg/types": "npm:4.0.0"
     axios: "npm:1.6.2"
     babel-plugin-module-resolver: "npm:5.0.0"
-    concurrently: "npm:8.2.2"
     cross-env: "npm:7.0.3"
     dayjs: "npm:1.11.10"
     eslint: "npm:8.54.0"
@@ -8648,9 +8778,9 @@ __metadata:
     lint-staged: "npm:15.1.0"
     lodash-es: "npm:4.17.21"
     ncp: "npm:2.0.0"
+    npm-run-all: "npm:4.1.5"
     prettier: "npm:3.1.0"
     rimraf: "npm:5.0.5"
-    tsconfig-paths: "npm:4.2.0"
     typescript: "npm:5.2.2"
     vitest: "npm:0.34.6"
     zod: "npm:3.22.4"
@@ -8684,8 +8814,7 @@ __metadata:
     mongoose: "npm:8.0.1"
     morgan: "npm:1.10.0"
     supertest: "npm:6.3.3"
-    ts-node: "npm:10.9.1"
-    ts-node-dev: "npm:2.0.0"
+    tsx: "npm:4.6.1"
     winston: "npm:3.11.0"
     winston-transport-sentry-node: "npm:2.7.0"
   peerDependenciesMeta:
@@ -8792,6 +8921,18 @@ __metadata:
     rfdc: "npm:^1.3.0"
     wrap-ansi: "npm:^8.1.0"
   checksum: 37b6501be84ebea66dcce07c5f86c224aff0c01c9fb43f5055cc38a063030281d58198aad0aad481f174438309831ddf5f763b890e820cd7b7b4f4a5dfa229c9
+  languageName: node
+  linkType: hard
+
+"load-json-file@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "load-json-file@npm:4.0.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.2"
+    parse-json: "npm:^4.0.0"
+    pify: "npm:^3.0.0"
+    strip-bom: "npm:^3.0.0"
+  checksum: 6b48f6a0256bdfcc8970be2c57f68f10acb2ee7e63709b386b2febb6ad3c86198f840889cdbe71d28f741cbaa2f23a7771206b138cd1bdd159564511ca37c1d5
   languageName: node
   linkType: hard
 
@@ -9064,13 +9205,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-error@npm:^1.1.1":
-  version: 1.3.6
-  resolution: "make-error@npm:1.3.6"
-  checksum: 171e458d86854c6b3fc46610cfacf0b45149ba043782558c6875d9f42f222124384ad0b468c92e996d815a8a2003817a710c0a160e49c1c394626f76fa45396f
-  languageName: node
-  linkType: hard
-
 "make-fetch-happen@npm:^13.0.0":
   version: 13.0.0
   resolution: "make-fetch-happen@npm:13.0.0"
@@ -9278,6 +9412,13 @@ __metadata:
   version: 1.5.0
   resolution: "memory-pager@npm:1.5.0"
   checksum: 2596e80c99fee24f05bd8a20cde2ee899012c996f4ec361ac76ed6f009f34149d733ac6f76880106ccd6a66d062ad439357578d383d429df66ba1278f68806e9
+  languageName: node
+  linkType: hard
+
+"memorystream@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "memorystream@npm:0.3.1"
+  checksum: 4bd164657711d9747ff5edb0508b2944414da3464b7fe21ac5c67cf35bba975c4b446a0124bd0f9a8be54cfc18faf92e92bd77563a20328b1ccf2ff04e9f39b9
   languageName: node
   linkType: hard
 
@@ -9874,7 +10015,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^1.0.3, mkdirp@npm:^1.0.4":
+"mkdirp@npm:^1.0.3":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
   bin:
@@ -10146,6 +10287,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nice-try@npm:^1.0.4":
+  version: 1.0.5
+  resolution: "nice-try@npm:1.0.5"
+  checksum: 95568c1b73e1d0d4069a3e3061a2102d854513d37bcfda73300015b7ba4868d3b27c198d1dbbd8ebdef4112fc2ed9e895d4a0f2e1cce0bd334f2a1346dc9205f
+  languageName: node
+  linkType: hard
+
 "no-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "no-case@npm:3.0.4"
@@ -10211,7 +10359,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-package-data@npm:^2.5.0":
+"normalize-package-data@npm:^2.3.2, normalize-package-data@npm:^2.5.0":
   version: 2.5.0
   resolution: "normalize-package-data@npm:2.5.0"
   dependencies:
@@ -10239,6 +10387,27 @@ __metadata:
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: e008c8142bcc335b5e38cf0d63cfd39d6cf2d97480af9abdbe9a439221fd4d749763bab492a8ee708ce7a194bb00c9da6d0a115018672310850489137b3da046
+  languageName: node
+  linkType: hard
+
+"npm-run-all@npm:4.1.5":
+  version: 4.1.5
+  resolution: "npm-run-all@npm:4.1.5"
+  dependencies:
+    ansi-styles: "npm:^3.2.1"
+    chalk: "npm:^2.4.1"
+    cross-spawn: "npm:^6.0.5"
+    memorystream: "npm:^0.3.1"
+    minimatch: "npm:^3.0.4"
+    pidtree: "npm:^0.3.0"
+    read-pkg: "npm:^3.0.0"
+    shell-quote: "npm:^1.6.1"
+    string.prototype.padend: "npm:^3.0.0"
+  bin:
+    npm-run-all: bin/npm-run-all/index.js
+    run-p: bin/run-p/index.js
+    run-s: bin/run-s/index.js
+  checksum: 736ee39bd35454d3efaa4a2e53eba6c523e2e17fba21a18edcce6b221f5cab62000bef16bb6ae8aff9e615831e6b0eb25ab51d52d60e6fa6f4ea880e4c6d31f4
   languageName: node
   linkType: hard
 
@@ -10622,6 +10791,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-json@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "parse-json@npm:4.0.0"
+  dependencies:
+    error-ex: "npm:^1.3.1"
+    json-parse-better-errors: "npm:^1.0.1"
+  checksum: 8d80790b772ccb1bcea4e09e2697555e519d83d04a77c2b4237389b813f82898943a93ffff7d0d2406203bdd0c30dcf95b1661e3a53f83d0e417f053957bef32
+  languageName: node
+  linkType: hard
+
 "parse-json@npm:^5.0.0, parse-json@npm:^5.2.0":
   version: 5.2.0
   resolution: "parse-json@npm:5.2.0"
@@ -10702,6 +10881,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-key@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "path-key@npm:2.0.1"
+  checksum: dd2044f029a8e58ac31d2bf34c34b93c3095c1481942960e84dd2faa95bbb71b9b762a106aead0646695330936414b31ca0bd862bf488a937ad17c8c5d73b32b
+  languageName: node
+  linkType: hard
+
 "path-key@npm:^3.0.0, path-key@npm:^3.1.0":
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
@@ -10737,6 +10923,15 @@ __metadata:
   version: 0.1.7
   resolution: "path-to-regexp@npm:0.1.7"
   checksum: 50a1ddb1af41a9e68bd67ca8e331a705899d16fb720a1ea3a41e310480948387daf603abb14d7b0826c58f10146d49050a1291ba6a82b78a382d1c02c0b8f905
+  languageName: node
+  linkType: hard
+
+"path-type@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "path-type@npm:3.0.0"
+  dependencies:
+    pify: "npm:^3.0.0"
+  checksum: 1332c632f1cac15790ebab8dd729b67ba04fc96f81647496feb1c2975d862d046f41e4b975dbd893048999b2cc90721f72924ad820acc58c78507ba7141a8e56
   languageName: node
   linkType: hard
 
@@ -10802,10 +10997,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pidtree@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "pidtree@npm:0.3.1"
+  bin:
+    pidtree: bin/pidtree.js
+  checksum: cd69b0182f749f45ab48584e3442c48c5dc4512502c18d5b0147a33b042c41a4db4269b9ce2f7c48f11833ee5e79d81f5ebc6f7bf8372d4ea55726f60dc505a1
+  languageName: node
+  linkType: hard
+
 "pify@npm:^2.0.0":
   version: 2.3.0
   resolution: "pify@npm:2.3.0"
   checksum: 551ff8ab830b1052633f59cb8adc9ae8407a436e06b4a9718bcb27dc5844b83d535c3a8512b388b6062af65a98c49bdc0dd523d8b2617b188f7c8fee457158dc
+  languageName: node
+  linkType: hard
+
+"pify@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pify@npm:3.0.0"
+  checksum: fead19ed9d801f1b1fcd0638a1ac53eabbb0945bf615f2f8806a8b646565a04a1b0e7ef115c951d225f042cca388fdc1cd3add46d10d1ed6951c20bd2998af10
   languageName: node
   linkType: hard
 
@@ -11335,6 +11546,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"read-pkg@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "read-pkg@npm:3.0.0"
+  dependencies:
+    load-json-file: "npm:^4.0.0"
+    normalize-package-data: "npm:^2.3.2"
+    path-type: "npm:^3.0.0"
+  checksum: 65acf2df89fbcd506b48b7ced56a255ba00adf7ecaa2db759c86cc58212f6fd80f1f0b7a85c848551a5d0685232e9b64f45c1fd5b48d85df2761a160767eeb93
+  languageName: node
+  linkType: hard
+
 "read-pkg@npm:^5.2.0":
   version: 5.2.0
   resolution: "read-pkg@npm:5.2.0"
@@ -11684,7 +11906,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.0.0, resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.2, resolve@npm:^1.22.4":
+"resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.2, resolve@npm:^1.22.4":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -11710,7 +11932,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.0.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
@@ -11785,7 +12007,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^2.6.1, rimraf@npm:^2.6.3":
+"rimraf@npm:^2.6.3":
   version: 2.7.1
   resolution: "rimraf@npm:2.7.1"
   dependencies:
@@ -11879,15 +12101,6 @@ __metadata:
   dependencies:
     queue-microtask: "npm:^1.2.2"
   checksum: 200b5ab25b5b8b7113f9901bfe3afc347e19bb7475b267d55ad0eb86a62a46d77510cb0f232507c9e5d497ebda569a08a9867d0d14f57a82ad5564d991588b39
-  languageName: node
-  linkType: hard
-
-"rxjs@npm:^7.8.1":
-  version: 7.8.1
-  resolution: "rxjs@npm:7.8.1"
-  dependencies:
-    tslib: "npm:^2.1.0"
-  checksum: 3c49c1ecd66170b175c9cacf5cef67f8914dcbc7cd0162855538d365c83fea631167cacb644b3ce533b2ea0e9a4d0b12175186985f89d75abe73dbd8f7f06f68
   languageName: node
   linkType: hard
 
@@ -12000,7 +12213,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.6.0, semver@npm:^5.7.0":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.5.0, semver@npm:^5.6.0, semver@npm:^5.7.0":
   version: 5.7.2
   resolution: "semver@npm:5.7.2"
   bin:
@@ -12139,12 +12352,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shebang-command@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "shebang-command@npm:1.2.0"
+  dependencies:
+    shebang-regex: "npm:^1.0.0"
+  checksum: 7b20dbf04112c456b7fc258622dafd566553184ac9b6938dd30b943b065b21dabd3776460df534cc02480db5e1b6aec44700d985153a3da46e7db7f9bd21326d
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
   dependencies:
     shebang-regex: "npm:^3.0.0"
   checksum: a41692e7d89a553ef21d324a5cceb5f686d1f3c040759c50aab69688634688c5c327f26f3ecf7001ebfd78c01f3c7c0a11a7c8bfd0a8bc9f6240d4f40b224e4e
+  languageName: node
+  linkType: hard
+
+"shebang-regex@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "shebang-regex@npm:1.0.0"
+  checksum: 9abc45dee35f554ae9453098a13fdc2f1730e525a5eb33c51f096cc31f6f10a4b38074c1ebf354ae7bffa7229506083844008dfc3bb7818228568c0b2dc1fff2
   languageName: node
   linkType: hard
 
@@ -12155,7 +12384,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.8.1":
+"shell-quote@npm:^1.6.1, shell-quote@npm:^1.8.1":
   version: 1.8.1
   resolution: "shell-quote@npm:1.8.1"
   checksum: 8cec6fd827bad74d0a49347057d40dfea1e01f12a6123bf82c4649f3ef152fc2bc6d6176e6376bffcd205d9d0ccb4f1f9acae889384d20baff92186f01ea455a
@@ -12302,7 +12531,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:^0.5.12, source-map-support@npm:^0.5.16, source-map-support@npm:~0.5.20":
+"source-map-support@npm:^0.5.16, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:
@@ -12339,13 +12568,6 @@ __metadata:
   dependencies:
     memory-pager: "npm:^1.0.2"
   checksum: 248c6ff7b5e354735e1daac4059222a29c9d291dfcf265daf675d13515eeaac454cfcccd687c8d134f86698b39abd7ad4d7434f7272dd6f8e41a00f21aae4194
-  languageName: node
-  linkType: hard
-
-"spawn-command@npm:0.0.2":
-  version: 0.0.2
-  resolution: "spawn-command@npm:0.0.2"
-  checksum: b22f2d71239e6e628a400831861ba747750bbb40c0a53323754cf7b84330b73d81e40ff1f9055e6d1971818679510208a9302e13d9ff3b32feb67e74d7a1b3ef
   languageName: node
   linkType: hard
 
@@ -12533,6 +12755,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string.prototype.padend@npm:^3.0.0":
+  version: 3.1.5
+  resolution: "string.prototype.padend@npm:3.1.5"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.2.0"
+    es-abstract: "npm:^1.22.1"
+  checksum: 94ba0d7a463c225d0337ebe4f5c150577d6d09fe56c798f77cd2b11f8d7c9b7b05e65b3c2a273f03529a3f155edb2d78b9c06b7a91f964f89796010a6cbc1dfa
+  languageName: node
+  linkType: hard
+
 "string.prototype.trim@npm:^1.2.8":
   version: 1.2.8
   resolution: "string.prototype.trim@npm:1.2.8"
@@ -12655,13 +12888,6 @@ __metadata:
   dependencies:
     min-indent: "npm:^1.0.1"
   checksum: 6b1fb4e22056867f5c9e7a6f3f45922d9a2436cac758607d58aeaac0d3b16ec40b1c43317de7900f1b8dd7a4107352fa47fb960f2c23566538c51e8585c8870e
-  languageName: node
-  linkType: hard
-
-"strip-json-comments@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "strip-json-comments@npm:2.0.1"
-  checksum: b509231cbdee45064ff4f9fd73609e2bcc4e84a4d508e9dd0f31f70356473fde18abfb5838c17d56fb236f5a06b102ef115438de0600b749e818a35fbbc48c43
   languageName: node
   linkType: hard
 
@@ -12842,7 +13068,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^8.0.0, supports-color@npm:^8.1.1":
+"supports-color@npm:^8.0.0":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
@@ -13092,15 +13318,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tree-kill@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "tree-kill@npm:1.2.2"
-  bin:
-    tree-kill: cli.js
-  checksum: 7b1b7c7f17608a8f8d20a162e7957ac1ef6cd1636db1aba92f4e072dc31818c2ff0efac1e3d91064ede67ed5dc57c565420531a8134090a12ac10cf792ab14d2
-  languageName: node
-  linkType: hard
-
 "trim-lines@npm:^3.0.0":
   version: 3.0.1
   resolution: "trim-lines@npm:3.0.1"
@@ -13138,82 +13355,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node-dev@npm:2.0.0":
-  version: 2.0.0
-  resolution: "ts-node-dev@npm:2.0.0"
-  dependencies:
-    chokidar: "npm:^3.5.1"
-    dynamic-dedupe: "npm:^0.3.0"
-    minimist: "npm:^1.2.6"
-    mkdirp: "npm:^1.0.4"
-    resolve: "npm:^1.0.0"
-    rimraf: "npm:^2.6.1"
-    source-map-support: "npm:^0.5.12"
-    tree-kill: "npm:^1.2.2"
-    ts-node: "npm:^10.4.0"
-    tsconfig: "npm:^7.0.0"
-  peerDependencies:
-    node-notifier: "*"
-    typescript: "*"
-  peerDependenciesMeta:
-    node-notifier:
-      optional: true
-  bin:
-    ts-node-dev: lib/bin.js
-    tsnd: lib/bin.js
-  checksum: 34f81407ede9284eccf47139e22bc85511c6d70e2b8dfae91c917ababc09ba947cc0791549ee7b2e5a69d26de40eedb23c6bdb4fac689ed07a302813bf966faa
-  languageName: node
-  linkType: hard
-
-"ts-node@npm:10.9.1, ts-node@npm:^10.4.0":
-  version: 10.9.1
-  resolution: "ts-node@npm:10.9.1"
-  dependencies:
-    "@cspotcode/source-map-support": "npm:^0.8.0"
-    "@tsconfig/node10": "npm:^1.0.7"
-    "@tsconfig/node12": "npm:^1.0.7"
-    "@tsconfig/node14": "npm:^1.0.0"
-    "@tsconfig/node16": "npm:^1.0.2"
-    acorn: "npm:^8.4.1"
-    acorn-walk: "npm:^8.1.1"
-    arg: "npm:^4.1.0"
-    create-require: "npm:^1.1.0"
-    diff: "npm:^4.0.1"
-    make-error: "npm:^1.1.1"
-    v8-compile-cache-lib: "npm:^3.0.1"
-    yn: "npm:3.1.1"
-  peerDependencies:
-    "@swc/core": ">=1.2.50"
-    "@swc/wasm": ">=1.2.50"
-    "@types/node": "*"
-    typescript: ">=2.7"
-  peerDependenciesMeta:
-    "@swc/core":
-      optional: true
-    "@swc/wasm":
-      optional: true
-  bin:
-    ts-node: dist/bin.js
-    ts-node-cwd: dist/bin-cwd.js
-    ts-node-esm: dist/bin-esm.js
-    ts-node-script: dist/bin-script.js
-    ts-node-transpile-only: dist/bin-transpile.js
-    ts-script: dist/bin-script-deprecated.js
-  checksum: 95187932fb83f3901e22546bd2feeac7d2feb4f412f42ac3a595f049a23e8dcf70516dffb51866391228ea2dbcfaea039e250fb2bb334d48a86ab2b6aea0ae2d
-  languageName: node
-  linkType: hard
-
-"tsconfig-paths@npm:4.2.0":
-  version: 4.2.0
-  resolution: "tsconfig-paths@npm:4.2.0"
-  dependencies:
-    json5: "npm:^2.2.2"
-    minimist: "npm:^1.2.6"
-    strip-bom: "npm:^3.0.0"
-  checksum: 09a5877402d082bb1134930c10249edeebc0211f36150c35e1c542e5b91f1047b1ccf7da1e59babca1ef1f014c525510f4f870de7c9bda470c73bb4e2721b3ea
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths@npm:^3.14.2":
   version: 3.14.2
   resolution: "tsconfig-paths@npm:3.14.2"
@@ -13226,18 +13367,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "tsconfig@npm:7.0.0"
-  dependencies:
-    "@types/strip-bom": "npm:^3.0.0"
-    "@types/strip-json-comments": "npm:0.0.30"
-    strip-bom: "npm:^3.0.0"
-    strip-json-comments: "npm:^2.0.0"
-  checksum: 7a5dec94b9e42017d93041b1962c174afde00fd8f3066eea81a5e5b743065e95f3bedebff0edbe215b2517f8cdace8c9f15651a78d5eb7409cad2fc107e5eb98
-  languageName: node
-  linkType: hard
-
 "tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
@@ -13245,7 +13374,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.0, tslib@npm:^2.6.2":
+"tslib@npm:^2.0.3, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb
@@ -13260,6 +13389,22 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 02f19e458ec78ead8fffbf711f834ad8ecd2cc6ade4ec0320790713dccc0a412b99e7fd907c4cda2a1dc602c75db6f12e0108e87a5afad4b2f9e90a24cabd5a2
+  languageName: node
+  linkType: hard
+
+"tsx@npm:4.6.1":
+  version: 4.6.1
+  resolution: "tsx@npm:4.6.1"
+  dependencies:
+    esbuild: "npm:~0.18.20"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.2"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 6c0291d7f3016d40fcd6b7014d77aef07c8051e19b480287381e5c5fb348aaf6dda2fa35b85ec2b9d1e83a45f9f6feb1992b5b630f8c06cc9dbdd8312ce39f41
   languageName: node
   linkType: hard
 
@@ -13660,13 +13805,6 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
-  languageName: node
-  linkType: hard
-
-"v8-compile-cache-lib@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "v8-compile-cache-lib@npm:3.0.1"
-  checksum: bdc36fb8095d3b41df197f5fb6f11e3a26adf4059df3213e3baa93810d8f0cc76f9a74aaefc18b73e91fe7e19154ed6f134eda6fded2e0f1c8d2272ed2d2d391
   languageName: node
   linkType: hard
 
@@ -14159,7 +14297,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^1.3.1":
+"which@npm:^1.2.9, which@npm:^1.3.1":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
   dependencies:
@@ -14337,7 +14475,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xtend@npm:>=4.0.0 <4.1.0-0, xtend@npm:^4.0.0":
+"xtend@npm:>=4.0.0 <4.1.0-0":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: 366ae4783eec6100f8a02dff02ac907bf29f9a00b82ac0264b4d8b832ead18306797e283cf19de776538babfdcb2101375ec5646b59f08c52128ac4ab812ed0e
@@ -14386,7 +14524,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.7.1, yargs@npm:^17.7.2":
+"yargs@npm:^17.7.1":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:
@@ -14408,13 +14546,6 @@ __metadata:
     buffer-crc32: "npm:~0.2.3"
     fd-slicer: "npm:~1.1.0"
   checksum: f265002af7541b9ec3589a27f5fb8f11cf348b53cc15e2751272e3c062cd73f3e715bc72d43257de71bbaecae446c3f1b14af7559e8ab0261625375541816422
-  languageName: node
-  linkType: hard
-
-"yn@npm:3.1.1":
-  version: 3.1.1
-  resolution: "yn@npm:3.1.1"
-  checksum: 0732468dd7622ed8a274f640f191f3eaf1f39d5349a1b72836df484998d7d9807fbea094e2f5486d6b0cd2414aad5775972df0e68f8604db89a239f0f4bf7443
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Use `lodash-es` with named imports
* Before we used `babel-plugin-lodash` to tree-shake `lodash` but seems like it's unmaintained
  * https://github.com/lodash/babel-plugin-lodash
* Total bundle size pretty much the same, 937kB -> 935kB (without tree-shaking 977kB)
* Since `lodash-es` exports ES modules, support was required. This was done by replacing `ts-node` with `tsx`
  * https://github.com/privatenumber/tsx
  * `concurrently` didn't work with `tsx` so it was replaced with `npm-run-all`: https://github.com/mysticatea/npm-run-all