### PR TITLE
Fix logger.error calls without message

### DIFF
--- a/server/src/features/statistics/fixer-helpers/wildFix.ts
+++ b/server/src/features/statistics/fixer-helpers/wildFix.ts
@@ -10,7 +10,7 @@ export const wildFix = async (
   try {
     data = readJson(year, event, type);
   } catch (error) {
-    logger.error(error);
+    logger.error("%s", error);
     return;
   }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -34,12 +34,12 @@ const startApp = async (): Promise<void> => {
 
   process.once("SIGINT", (signal: string) => {
     closeServer(server, signal).catch((error: unknown) => {
-      logger.error(error);
+      logger.error("%s", error);
     });
   });
   process.once("SIGTERM", (signal: string) => {
     closeServer(server, signal).catch((error: unknown) => {
-      logger.error(error);
+      logger.error("%s", error);
     });
   });
 };
@@ -53,7 +53,7 @@ const init = (): void => {
   }
 
   startApp().catch((error: unknown) => {
-    logger.error(error);
+    logger.error("%s", error);
   });
 };
 

--- a/server/src/test/scripts/loadKompassiDataToDb.ts
+++ b/server/src/test/scripts/loadKompassiDataToDb.ts
@@ -18,5 +18,5 @@ const loadKompassiDataToDb = async (): Promise<void> => {
 };
 
 loadKompassiDataToDb().catch((error: unknown) => {
-  logger.error(error);
+  logger.error("%s", error);
 });

--- a/server/src/test/scripts/removeInvalidProgramItems.ts
+++ b/server/src/test/scripts/removeInvalidProgramItems.ts
@@ -6,7 +6,7 @@ const removeInvalidProgramItems = async (): Promise<void> => {
   try {
     await db.connectToDb();
   } catch (error) {
-    logger.error(error);
+    logger.error("%s", error);
     // eslint-disable-next-line no-restricted-syntax -- Test script
     throw error;
   }
@@ -22,12 +22,12 @@ const removeInvalidProgramItems = async (): Promise<void> => {
   try {
     await db.gracefulExit();
   } catch (error) {
-    logger.error(error);
+    logger.error("%s", error);
     // eslint-disable-next-line no-restricted-syntax -- Test script
     throw error;
   }
 };
 
 removeInvalidProgramItems().catch((error: unknown) => {
-  logger.error(error);
+  logger.error("%s", error);
 });

--- a/server/src/test/scripts/testAssignment.ts
+++ b/server/src/test/scripts/testAssignment.ts
@@ -44,5 +44,5 @@ const init = async (): Promise<void> => {
 };
 
 init().catch((error: unknown) => {
-  logger.error(error);
+  logger.error("%s", error);
 });

--- a/server/src/test/scripts/testUpdateProgramItemPopularity.ts
+++ b/server/src/test/scripts/testUpdateProgramItemPopularity.ts
@@ -9,7 +9,7 @@ const testUpdateProgramItemPopularity = async (): Promise<void> => {
   try {
     await db.connectToDb();
   } catch (error) {
-    logger.error(error);
+    logger.error("%s", error);
   }
 
   try {
@@ -21,10 +21,10 @@ const testUpdateProgramItemPopularity = async (): Promise<void> => {
   try {
     await db.gracefulExit();
   } catch (error) {
-    logger.error(error);
+    logger.error("%s", error);
   }
 };
 
 testUpdateProgramItemPopularity().catch((error: unknown) => {
-  logger.error(error);
+  logger.error("%s", error);
 });

--- a/server/src/test/scripts/testVerifyResults.ts
+++ b/server/src/test/scripts/testVerifyResults.ts
@@ -6,22 +6,22 @@ const testVerifyResults = async (): Promise<void> => {
   try {
     await db.connectToDb();
   } catch (error) {
-    logger.error(error);
+    logger.error("%s", error);
   }
 
   try {
     await verifyUserSignups();
   } catch (error) {
-    logger.error(error);
+    logger.error("%s", error);
   }
 
   try {
     await db.gracefulExit();
   } catch (error) {
-    logger.error(error);
+    logger.error("%s", error);
   }
 };
 
 testVerifyResults().catch((error: unknown) => {
-  logger.error(error);
+  logger.error("%s", error);
 });

--- a/server/src/test/test-data-generation/parseCliOptions.ts
+++ b/server/src/test/test-data-generation/parseCliOptions.ts
@@ -28,5 +28,5 @@ const parseCliOptions = async (): Promise<void> => {
 };
 
 parseCliOptions().catch((error: unknown) => {
-  logger.error(error);
+  logger.error("%s", error);
 });

--- a/server/src/utils/generateSerials.ts
+++ b/server/src/utils/generateSerials.ts
@@ -15,7 +15,7 @@ const generateSerials = async (): Promise<void> => {
     try {
       await db.connectToDb();
     } catch (error) {
-      logger.error(error);
+      logger.error("%s", error);
     }
 
     try {
@@ -28,10 +28,10 @@ const generateSerials = async (): Promise<void> => {
   try {
     await db.gracefulExit();
   } catch (error) {
-    logger.error(error);
+    logger.error("%s", error);
   }
 };
 
 generateSerials().catch((error: unknown) => {
-  logger.error(error);
+  logger.error("%s", error);
 });

--- a/server/src/utils/server.ts
+++ b/server/src/utils/server.ts
@@ -29,7 +29,7 @@ export const startServer = async ({
   try {
     await db.connectToDb(dbConnString, dbName);
   } catch (error) {
-    logger.error(error);
+    logger.error("%s", error);
   }
 
   const app = express();
@@ -162,7 +162,7 @@ export const closeServer = async (
   try {
     await db.gracefulExit();
   } catch (error) {
-    logger.error(error);
+    logger.error("%s", error);
   }
 
   logger.info("Shutdown completed, bye");


### PR DESCRIPTION
Fix `logger.error()` calls without message