### PR TITLE
Fixes to new signups list

### DIFF
--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -342,6 +342,7 @@ export const translationEN = {
     noAttendees: "No {{ATTENDEE_TYPE}}",
     loginLink: "Log in",
     loginLinkEnding: " to see {{ATTENDEE_TYPE}}.",
+    signupQuestionAriaLabel: "Signup question",
   },
   attendeeType: {
     player: "player",

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -341,7 +341,7 @@ export const translationEN = {
     hideAttendees: "Hide {{ATTENDEE_TYPE}}",
     noAttendees: "No {{ATTENDEE_TYPE}}",
     loginLink: "Log in",
-    loginLinkEnding: " to see {{ATTENDEE_TYPE}}",
+    loginLinkEnding: " to see {{ATTENDEE_TYPE}}.",
   },
   attendeeType: {
     player: "player",

--- a/client/src/locales/fi.ts
+++ b/client/src/locales/fi.ts
@@ -344,6 +344,7 @@ export const translationFI = {
     noAttendees: "Ei {{ATTENDEE_TYPE}}",
     loginLink: "Kirjaudu sisään",
     loginLinkEnding: " nähdäksesi {{ATTENDEE_TYPE}}.",
+    signupQuestionAriaLabel: "Lisätietokysymys",
   },
   attendeeType: {
     player: "pelaaja",

--- a/client/src/locales/fi.ts
+++ b/client/src/locales/fi.ts
@@ -343,7 +343,7 @@ export const translationFI = {
     hideAttendees: "Piilota {{ATTENDEE_TYPE}}",
     noAttendees: "Ei {{ATTENDEE_TYPE}}",
     loginLink: "Kirjaudu sisään",
-    loginLinkEnding: " nähdäksesi {{ATTENDEE_TYPE}}",
+    loginLinkEnding: " nähdäksesi {{ATTENDEE_TYPE}}.",
   },
   attendeeType: {
     player: "pelaaja",

--- a/client/src/views/all-program-items/components/AdminActionCard.tsx
+++ b/client/src/views/all-program-items/components/AdminActionCard.tsx
@@ -18,6 +18,7 @@ import {
   SignupQuestionType,
 } from "shared/types/models/settings";
 import { Checkbox } from "client/components/Checkbox";
+import { UncontrolledInput } from "client/components/UncontrolledInput";
 
 interface Props {
   programItem: ProgramItem;
@@ -217,9 +218,9 @@ export const AdminActionCard = ({ programItem }: Props): ReactElement => {
 
           {questionType === SignupQuestionType.SELECT && (
             <>
-              <div>
+              <InputsContainer>
                 <span>{t("signupQuestion.inFinnish")}</span>
-                <input
+                <UncontrolledInput
                   onChange={(event) => {
                     const newState = selectOptions;
                     newState[0] = {
@@ -229,7 +230,7 @@ export const AdminActionCard = ({ programItem }: Props): ReactElement => {
                     setSelectOptions(newState);
                   }}
                 />
-                <input
+                <UncontrolledInput
                   onChange={(event) => {
                     const newState = selectOptions;
                     newState[1] = {
@@ -239,7 +240,7 @@ export const AdminActionCard = ({ programItem }: Props): ReactElement => {
                     setSelectOptions(newState);
                   }}
                 />{" "}
-                <input
+                <UncontrolledInput
                   onChange={(event) => {
                     const newState = selectOptions;
                     newState[2] = {
@@ -249,7 +250,7 @@ export const AdminActionCard = ({ programItem }: Props): ReactElement => {
                     setSelectOptions(newState);
                   }}
                 />
-                <input
+                <UncontrolledInput
                   onChange={(event) => {
                     const newState = selectOptions;
                     newState[3] = {
@@ -259,10 +260,10 @@ export const AdminActionCard = ({ programItem }: Props): ReactElement => {
                     setSelectOptions(newState);
                   }}
                 />
-              </div>
-              <div>
+              </InputsContainer>
+              <InputsContainer>
                 <span>{t("signupQuestion.inEnglish")}</span>
-                <input
+                <UncontrolledInput
                   onChange={(event) => {
                     const newState = selectOptions;
                     newState[0] = {
@@ -272,7 +273,7 @@ export const AdminActionCard = ({ programItem }: Props): ReactElement => {
                     setSelectOptions(newState);
                   }}
                 />
-                <input
+                <UncontrolledInput
                   onChange={(event) => {
                     const newState = selectOptions;
                     newState[1] = {
@@ -282,7 +283,7 @@ export const AdminActionCard = ({ programItem }: Props): ReactElement => {
                     setSelectOptions(newState);
                   }}
                 />{" "}
-                <input
+                <UncontrolledInput
                   onChange={(event) => {
                     const newState = selectOptions;
                     newState[2] = {
@@ -292,7 +293,7 @@ export const AdminActionCard = ({ programItem }: Props): ReactElement => {
                     setSelectOptions(newState);
                   }}
                 />
-                <input
+                <UncontrolledInput
                   onChange={(event) => {
                     const newState = selectOptions;
                     newState[3] = {
@@ -302,7 +303,7 @@ export const AdminActionCard = ({ programItem }: Props): ReactElement => {
                     setSelectOptions(newState);
                   }}
                 />
-              </div>
+              </InputsContainer>
             </>
           )}
 
@@ -348,4 +349,13 @@ const WithRowGap = styled.div`
   row-gap: 8px;
   display: grid;
   padding-top: 8px;
+`;
+
+const InputsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  @media (min-width: ${(props) => props.theme.breakpointPhone}) {
+    max-width: 40%;
+  }
 `;

--- a/client/src/views/all-program-items/components/AllProgramItemsList.tsx
+++ b/client/src/views/all-program-items/components/AllProgramItemsList.tsx
@@ -86,9 +86,7 @@ export const AllProgramItemsList = ({ programItems }: Props): ReactElement => {
                 isAlwaysExpanded={false}
                 programItem={programItem}
                 startTime={startTime}
-                attendees={
-                  programItemSignups?.users.map((s) => s.username) ?? []
-                }
+                signups={programItemSignups?.users ?? []}
                 signupStrategy={timeslotSignupStrategy}
                 lotterySignups={ownOrGroupCreatorLotterySignups}
                 directSignups={directSignups}

--- a/client/src/views/all-program-items/components/AllProgramItemsList.tsx
+++ b/client/src/views/all-program-items/components/AllProgramItemsList.tsx
@@ -42,6 +42,15 @@ export const AllProgramItemsList = ({ programItems }: Props): ReactElement => {
 
   const [loading, setLoading] = useState(false);
 
+  const signupQuestions = useAppSelector(
+    (state) => state.admin.signupQuestions,
+  );
+
+  const getPublicSignupQuestion = (programItemId: string) =>
+    signupQuestions.find(
+      (s) => s.programItemId === programItemId && !s.private,
+    );
+
   const ownOrGroupCreatorLotterySignups = getLotterySignups({
     lotterySignups,
     isGroupCreator,
@@ -96,6 +105,9 @@ export const AllProgramItemsList = ({ programItems }: Props): ReactElement => {
                 loggedIn={loggedIn}
                 userGroup={userGroup}
                 favoriteProgramItems={favoriteProgramItems}
+                publicSignupQuestion={getPublicSignupQuestion(
+                  programItem.programItemId,
+                )}
               />
             );
           })}

--- a/client/src/views/all-program-items/components/ProgramItemEntry.tsx
+++ b/client/src/views/all-program-items/components/ProgramItemEntry.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
-import { ProgramItem } from "shared/types/models/programItem";
+import { ProgramItem, UserSignup } from "shared/types/models/programItem";
 import { SignupStrategy } from "shared/config/sharedConfigTypes";
 import { Signup, UserGroup } from "shared/types/models/user";
 import { RaisedCard } from "client/components/RaisedCard";
@@ -17,7 +17,7 @@ import { ProgramItemHead } from "client/views/all-program-items/components/Progr
 interface Props {
   programItem: ProgramItem;
   startTime: string;
-  attendees: string[];
+  signups: UserSignup[];
   signupStrategy: SignupStrategy;
   lotterySignups: readonly Signup[];
   directSignups: readonly Signup[];
@@ -33,7 +33,7 @@ interface Props {
 export const ProgramItemEntry = ({
   programItem,
   startTime,
-  attendees,
+  signups,
   signupStrategy,
   lotterySignups,
   directSignups,
@@ -88,7 +88,7 @@ export const ProgramItemEntry = ({
     >
       <ProgramItemHead
         programItem={programItem}
-        attendees={attendees}
+        signups={signups}
         signupStrategy={signupStrategy}
         username={username}
         loggedIn={loggedIn}
@@ -104,7 +104,7 @@ export const ProgramItemEntry = ({
         startTime={startTime}
         lotterySignups={lotterySignups}
         programItem={programItem}
-        attendees={attendees.length}
+        attendees={signups.length}
         loading={loading}
         setLoading={setLoading}
       />

--- a/client/src/views/all-program-items/components/ProgramItemEntry.tsx
+++ b/client/src/views/all-program-items/components/ProgramItemEntry.tsx
@@ -13,6 +13,7 @@ import { config } from "shared/config";
 import { ProgramItemView } from "client/views/all-program-items/components/ProgramItemView";
 import { SignupInfo } from "client/views/all-program-items/components/SignupInfo";
 import { ProgramItemHead } from "client/views/all-program-items/components/ProgramItemHead";
+import { SignupQuestion } from "shared/types/models/settings";
 
 interface Props {
   programItem: ProgramItem;
@@ -28,6 +29,7 @@ interface Props {
   loggedIn: boolean;
   userGroup: UserGroup;
   favoriteProgramItems: readonly ProgramItem[];
+  publicSignupQuestion?: SignupQuestion;
 }
 
 export const ProgramItemEntry = ({
@@ -44,6 +46,7 @@ export const ProgramItemEntry = ({
   loggedIn,
   userGroup,
   favoriteProgramItems,
+  publicSignupQuestion,
 }: Props): ReactElement => {
   const { t } = useTranslation();
 
@@ -94,6 +97,7 @@ export const ProgramItemEntry = ({
         loggedIn={loggedIn}
         userGroup={userGroup}
         favoriteProgramItems={favoriteProgramItems}
+        publicSignupQuestion={publicSignupQuestion}
       />
       <ProgramItemView
         programItem={programItem}

--- a/client/src/views/all-program-items/components/ProgramItemHead.tsx
+++ b/client/src/views/all-program-items/components/ProgramItemHead.tsx
@@ -16,6 +16,7 @@ import { config } from "shared/config";
 import { isRevolvingDoorWorkshop } from "client/utils/isRevolvingDoorWorkshop";
 import { SignupsInfo } from "client/views/all-program-items/components/SignupsInfo";
 import { AppRoute } from "client/app/AppRoutes";
+import { SignupQuestion } from "shared/types/models/settings";
 
 interface Props {
   programItem: ProgramItem;
@@ -25,6 +26,7 @@ interface Props {
   loggedIn: boolean;
   userGroup: UserGroup;
   favoriteProgramItems: readonly ProgramItem[];
+  publicSignupQuestion?: SignupQuestion;
 }
 
 export const ProgramItemHead = ({
@@ -35,6 +37,7 @@ export const ProgramItemHead = ({
   loggedIn,
   userGroup,
   favoriteProgramItems,
+  publicSignupQuestion,
 }: Props): ReactElement => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
@@ -125,6 +128,7 @@ export const ProgramItemHead = ({
               programItem={programItem}
               signups={signups}
               isLoggedIn={loggedIn}
+              publicSignupQuestion={publicSignupQuestion}
             />
           </Row>
         )}

--- a/client/src/views/all-program-items/components/ProgramItemHead.tsx
+++ b/client/src/views/all-program-items/components/ProgramItemHead.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from "react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { ProgramItem } from "shared/types/models/programItem";
+import { ProgramItem, UserSignup } from "shared/types/models/programItem";
 import { SignupStrategy } from "shared/config/sharedConfigTypes";
 import { UserGroup } from "shared/types/models/user";
 import { FavoriteButton } from "client/components/FavoriteButton";
@@ -19,7 +19,7 @@ import { AppRoute } from "client/app/AppRoutes";
 
 interface Props {
   programItem: ProgramItem;
-  attendees: string[];
+  signups: UserSignup[];
   signupStrategy: SignupStrategy;
   username: string;
   loggedIn: boolean;
@@ -29,7 +29,7 @@ interface Props {
 
 export const ProgramItemHead = ({
   programItem,
-  attendees,
+  signups,
   signupStrategy,
   username,
   loggedIn,
@@ -123,18 +123,18 @@ export const ProgramItemHead = ({
               isEnterGameMode={isEnterGameMode}
               isNormalSignup={isNormalSignup}
               programItem={programItem}
-              attendees={attendees}
+              signups={signups}
               isLoggedIn={loggedIn}
             />
           </Row>
         )}
 
-        {attendees.length < programItem.minAttendance && (
+        {signups.length < programItem.minAttendance && (
           <Row>
             {t("signup.attendeesNeeded", {
-              COUNT: programItem.minAttendance - attendees.length,
+              COUNT: programItem.minAttendance - signups.length,
               ATTENDEE_TYPE:
-                programItem.minAttendance - attendees.length === 1
+                programItem.minAttendance - signups.length === 1
                   ? t(
                       `attendeeType.${getAttendeeType(programItem.programType)}`,
                     )

--- a/client/src/views/all-program-items/components/ProgramItemPage.tsx
+++ b/client/src/views/all-program-items/components/ProgramItemPage.tsx
@@ -57,6 +57,14 @@ export const ProgramItemPage = (): ReactElement => {
         programItemSignup.programItemId === foundProgramItem?.programItemId,
     )?.users ?? [];
 
+  const signupQuestions = useAppSelector(
+    (state) => state.admin.signupQuestions,
+  );
+
+  const publicSignupQuestion = signupQuestions.find(
+    (s) => s.programItemId === programItemId && !s.private,
+  );
+
   useEffect(() => {
     setLoading(false);
   }, [foundProgramItem]);
@@ -82,6 +90,7 @@ export const ProgramItemPage = (): ReactElement => {
           loggedIn={loggedIn}
           userGroup={userGroup}
           favoriteProgramItems={favoriteProgramItems}
+          publicSignupQuestion={publicSignupQuestion}
         />
       )}
       {!loading && !foundProgramItem && (

--- a/client/src/views/all-program-items/components/ProgramItemPage.tsx
+++ b/client/src/views/all-program-items/components/ProgramItemPage.tsx
@@ -51,13 +51,11 @@ export const ProgramItemPage = (): ReactElement => {
   const foundProgramItem = programItems.find(
     (programItem) => programItem.programItemId === programItemId,
   );
-  const attendees =
-    signups
-      .find(
-        (programItemSignup) =>
-          programItemSignup.programItemId === foundProgramItem?.programItemId,
-      )
-      ?.users.map((user) => user.username) ?? [];
+  const programSignups =
+    signups.find(
+      (programItemSignup) =>
+        programItemSignup.programItemId === foundProgramItem?.programItemId,
+    )?.users ?? [];
 
   useEffect(() => {
     setLoading(false);
@@ -72,7 +70,7 @@ export const ProgramItemPage = (): ReactElement => {
           isAlwaysExpanded={true}
           programItem={foundProgramItem}
           startTime={foundProgramItem.startTime}
-          attendees={attendees}
+          signups={programSignups}
           signupStrategy={
             foundProgramItem.signupStrategy ?? SignupStrategy.DIRECT
           }

--- a/client/src/views/all-program-items/components/SignupsInfo.tsx
+++ b/client/src/views/all-program-items/components/SignupsInfo.tsx
@@ -79,7 +79,7 @@ export const SignupsInfo = ({
             </AttendeeList>
           )}
 
-          {isExpanded && attendeesText.length > 0 && !isLoggedIn && (
+          {isExpanded && attendees.length > 0 && !isLoggedIn && (
             <AttendeeText>
               <Link to={"/login"}>{t("signup.loginLink")}</Link>
               {t("signup.loginLinkEnding", {
@@ -113,7 +113,7 @@ const SignupsInfoContainer = styled.div`
 `;
 
 const AttendeeText = styled.p`
-  margin: 12px 0 0 12px;
+  margin: 4px 0 0 12px;
 `;
 
 const NoAttendeesText = styled(AttendeeText)`

--- a/client/src/views/all-program-items/components/SignupsInfo.tsx
+++ b/client/src/views/all-program-items/components/SignupsInfo.tsx
@@ -2,8 +2,13 @@ import { ReactElement, useState } from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
+import { sortBy } from "lodash-es";
 import { getAttendeeType } from "client/utils/getAttendeeType";
-import { ProgramItem, ProgramType } from "shared/types/models/programItem";
+import {
+  ProgramItem,
+  ProgramType,
+  UserSignup,
+} from "shared/types/models/programItem";
 import { isRevolvingDoorWorkshop } from "client/utils/isRevolvingDoorWorkshop";
 import { ExpandButton } from "client/components/ExpandButton";
 
@@ -12,7 +17,7 @@ interface Props {
   isNormalSignup: boolean;
   isLoggedIn: boolean;
   programItem: ProgramItem;
-  attendees: string[];
+  signups: UserSignup[];
 }
 
 export const SignupsInfo = ({
@@ -20,7 +25,7 @@ export const SignupsInfo = ({
   isNormalSignup,
   isLoggedIn,
   programItem,
-  attendees,
+  signups,
 }: Props): ReactElement => {
   const { t } = useTranslation();
 
@@ -48,7 +53,7 @@ export const SignupsInfo = ({
       {isEnterGameMode && isNormalSignup && isValidMaxAttendanceValue && (
         <SignupsInfoContainer>
           {t("signup.signupCount", {
-            ATTENDEE_COUNT: attendees.length,
+            ATTENDEE_COUNT: signups.length,
             MAX_ATTENDANCE: programItem.maxAttendance,
           })}
           <ExpandButton
@@ -61,7 +66,7 @@ export const SignupsInfo = ({
             onClick={() => setIsExpanded(!isExpanded)}
           />
 
-          {isExpanded && attendees.length === 0 && (
+          {isExpanded && signups.length === 0 && (
             <NoAttendeesText>
               {t("signup.noAttendees", {
                 ATTENDEE_TYPE: t(
@@ -71,15 +76,15 @@ export const SignupsInfo = ({
             </NoAttendeesText>
           )}
 
-          {isExpanded && attendees.length > 0 && isLoggedIn && (
+          {isExpanded && signups.length > 0 && isLoggedIn && (
             <AttendeeList>
-              {attendees.sort().map((attendee) => (
-                <li key={attendee}>{attendee}</li>
+              {sortBy(signups, ["username"]).map((signup) => (
+                <li key={signup.username}>{signup.username}</li>
               ))}
             </AttendeeList>
           )}
 
-          {isExpanded && attendees.length > 0 && !isLoggedIn && (
+          {isExpanded && signups.length > 0 && !isLoggedIn && (
             <AttendeeText>
               <Link to={"/login"}>{t("signup.loginLink")}</Link>
               {t("signup.loginLinkEnding", {

--- a/client/src/views/all-program-items/components/SignupsInfo.tsx
+++ b/client/src/views/all-program-items/components/SignupsInfo.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { sortBy } from "lodash-es";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getAttendeeType } from "client/utils/getAttendeeType";
 import {
   ProgramItem,
@@ -11,6 +12,7 @@ import {
 } from "shared/types/models/programItem";
 import { isRevolvingDoorWorkshop } from "client/utils/isRevolvingDoorWorkshop";
 import { ExpandButton } from "client/components/ExpandButton";
+import { SignupQuestion } from "shared/types/models/settings";
 
 interface Props {
   isEnterGameMode: boolean;
@@ -18,6 +20,7 @@ interface Props {
   isLoggedIn: boolean;
   programItem: ProgramItem;
   signups: UserSignup[];
+  publicSignupQuestion?: SignupQuestion;
 }
 
 export const SignupsInfo = ({
@@ -26,8 +29,9 @@ export const SignupsInfo = ({
   isLoggedIn,
   programItem,
   signups,
+  publicSignupQuestion,
 }: Props): ReactElement => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
@@ -77,11 +81,32 @@ export const SignupsInfo = ({
           )}
 
           {isExpanded && signups.length > 0 && isLoggedIn && (
-            <AttendeeList>
-              {sortBy(signups, ["username"]).map((signup) => (
-                <li key={signup.username}>{signup.username}</li>
-              ))}
-            </AttendeeList>
+            <>
+              {publicSignupQuestion && (
+                <QuestionContainer>
+                  <FontAwesomeIcon
+                    aria-label={t("signup.signupQuestionAriaLabel")}
+                    icon={["far", "comment"]}
+                  />
+                  <span>
+                    {": "}
+                    {i18n.language === "fi"
+                      ? publicSignupQuestion.questionFi
+                      : publicSignupQuestion.questionEn}
+                  </span>
+                </QuestionContainer>
+              )}
+              <AttendeeList>
+                {sortBy(signups, ["username"]).map((signup) => (
+                  <li key={signup.username}>
+                    {signup.username}
+                    {publicSignupQuestion && (
+                      <AnswerText>: {signup.signupMessage}</AnswerText>
+                    )}
+                  </li>
+                ))}
+              </AttendeeList>
+            </>
           )}
 
           {isExpanded && signups.length > 0 && !isLoggedIn && (
@@ -117,8 +142,16 @@ const SignupsInfoContainer = styled.div`
   gap: 8px;
 `;
 
+const QuestionContainer = styled.div`
+  color: ${(props) => props.theme.textSecondary};
+`;
+
 const AttendeeText = styled.p`
   margin: 4px 0 0 12px;
+`;
+
+const AnswerText = styled.span`
+  color: ${(props) => props.theme.textSecondary};
 `;
 
 const NoAttendeesText = styled(AttendeeText)`


### PR DESCRIPTION
- Ei näytetä kahta ristiriitaista UI-viestiä, jos käyttäjä ei ole logannut sisään
- Näytetään julkinen ilmoittautumisen lisätietokysmys ohjelmanumerokortilla
- Siistitään vähän lisätietokysymyksen lisäämisen leiskaa

Monivalintalisätietokysymys:
<img width="728" alt="Screenshot 2024-06-25 at 18 46 46" src="https://github.com/con2/konsti/assets/9348525/a51af21c-1a3b-4759-b251-4bb5320bcc7a">

Tekstimuotoinen lisätietokysymys:
<img width="538" alt="Screenshot 2024-06-25 at 18 42 39" src="https://github.com/con2/konsti/assets/9348525/c816e68e-85e5-48ea-91de-6f33ff898299">
