### PR TITLE
Set workshop signups to start 4h before program item

### DIFF
--- a/shared/config/sharedConfig.ts
+++ b/shared/config/sharedConfig.ts
@@ -24,6 +24,7 @@ export interface SharedConfig {
   directSignupWindows: Partial<
     Record<ProgramType, ArrMin1<SignupWindow>>
   > | null;
+  rollingSignupStartProgramTypes: ProgramType[];
   directSignupAlwaysOpenIds: string[];
   tracesSampleRate: number;
   enableSentryInDev: boolean;
@@ -101,34 +102,6 @@ export const sharedConfig: SharedConfig = {
       },
     ],
 
-    workshop: [
-      // Friday
-      {
-        signupWindowStart: dayjs(`${friday}T12:00:00Z`), // Fri 15:00 GMT+3
-        signupWindowClose: dayjs(`${friday}T21:00:00Z`), // Fri 24:00 GMT+3
-      },
-      // Saturday morning / day
-      {
-        signupWindowStart: dayjs(`${friday}T15:00:00Z`), // Fri 18:00 GMT+3
-        signupWindowClose: dayjs(`${saturday}T11:00:00Z`), // Sat 14:00 GMT+3
-      },
-      // Saturday day / evening
-      {
-        signupWindowStart: dayjs(`${saturday}T06:00:00Z`), // Sat 09:00 GMT+3
-        signupWindowClose: dayjs(`${saturday}T21:00:00Z`), // Sat 24:00 GMT+3
-      },
-      // Saturday evening / sunday morning
-      {
-        signupWindowStart: dayjs(`${saturday}T15:00:00Z`), // Sat 18:00 GMT+3
-        signupWindowClose: dayjs(`${sunday}T11:00:00Z`), // Sun 14:00 GMT+3
-      },
-      // Sunday
-      {
-        signupWindowStart: dayjs(`${sunday}T06:00:00Z`), // Sun 09:00 GMT+3
-        signupWindowClose: dayjs(`${sunday}T21:00:00Z`), // Sun 24:00 GMT+3
-      },
-    ],
-
     experiencePoint: [
       // Whole convention Fri - Sun
       {
@@ -145,6 +118,8 @@ export const sharedConfig: SharedConfig = {
       },
     ],
   },
+
+  rollingSignupStartProgramTypes: [ProgramType.WORKSHOP],
 
   // These program items have their signup always open even if signup mode is set to algorithm
   directSignupAlwaysOpenIds: [

--- a/shared/utils/signupTimes.test.ts
+++ b/shared/utils/signupTimes.test.ts
@@ -11,177 +11,182 @@ import {
 import { config } from "shared/config";
 import { ProgramType } from "shared/types/models/programItem";
 
+const friday = "2023-07-28";
+const saturday = "2023-07-29";
+const sunday = "2023-07-30";
+
 beforeEach(() => {
   vi.spyOn(config, "shared").mockReturnValue({
     ...config.shared(),
-    conventionStartTime: "2023-07-28T12:00:00Z",
+    conventionStartTime: `${friday}T12:00:00Z`,
     twoPhaseSignupProgramTypes: [ProgramType.TABLETOP_RPG],
     directSignupWindows: {
       larp: [
         // Friday
         {
-          signupWindowStart: dayjs("2023-07-28T12:00:00Z"), // Fri 15:00 GMT+3
-          signupWindowClose: dayjs("2023-07-28T21:00:00Z"), // Fri 24:00 GMT+3
+          signupWindowStart: dayjs(`${friday}T12:00:00Z`), // Fri 15:00 GMT+3
+          signupWindowClose: dayjs(`${friday}T21:00:00Z`), // Fri 24:00 GMT+3
         },
         // Saturday morning / day
         {
-          signupWindowStart: dayjs("2023-07-28T15:00:00Z"), // Fri 18:00 GMT+3
-          signupWindowClose: dayjs("2023-07-29T15:00:00Z"), // Sat 18:00 GMT+3
+          signupWindowStart: dayjs(`${friday}T15:00:00Z`), // Fri 18:00 GMT+3
+          signupWindowClose: dayjs(`${saturday}T15:00:00Z`), // Sat 18:00 GMT+3
         },
         // Saturday evening
         {
-          signupWindowStart: dayjs("2023-07-29T08:00:00Z"), // Sat 11:00 GMT+3
-          signupWindowClose: dayjs("2023-07-29T21:00:00Z"), // Sat 24:00 GMT+3
+          signupWindowStart: dayjs(`${saturday}T08:00:00Z`), // Sat 11:00 GMT+3
+          signupWindowClose: dayjs(`${saturday}T21:00:00Z`), // Sat 24:00 GMT+3
         },
         // Sunday
         {
-          signupWindowStart: dayjs("2023-07-29T12:00:00Z"), // Sat 15:00 GMT+3
-          signupWindowClose: dayjs("2023-07-30T21:00:00Z"), // Sun 24:00 GMT+3
+          signupWindowStart: dayjs(`${saturday}T12:00:00Z`), // Sat 15:00 GMT+3
+          signupWindowClose: dayjs(`${sunday}T21:00:00Z`), // Sun 24:00 GMT+3
         },
       ],
     },
+    rollingSignupStartProgramTypes: [ProgramType.WORKSHOP],
   });
 });
 
 describe(`Algorithm signup`, () => {
   test("RPG starting at 15:00 should have signup starting at 15:00", () => {
-    const startTime = "2023-07-28T12:00:00.000Z";
+    const startTime = `${friday}T12:00:00.000Z`;
     const signupStartTime = getAlgorithmSignupStartTime(startTime);
-    expect(signupStartTime.toISOString()).toEqual("2023-07-28T12:00:00.000Z");
+    expect(signupStartTime.toISOString()).toEqual(`${friday}T12:00:00.000Z`);
   });
 
   test("RPG starting at 16:00 should have signup starting at 15:00", () => {
-    const startTime = "2023-07-28T13:00:00.000Z";
+    const startTime = `${friday}T13:00:00.000Z`;
     const signupStartTime = getAlgorithmSignupStartTime(startTime);
-    expect(signupStartTime.toISOString()).toEqual("2023-07-28T12:00:00.000Z");
+    expect(signupStartTime.toISOString()).toEqual(`${friday}T12:00:00.000Z`);
   });
 
   test("RPG starting at 17:00 should have signup starting at 15:00", () => {
-    const startTime = "2023-07-28T14:00:00.000Z";
+    const startTime = `${friday}T14:00:00.000Z`;
     const signupStartTime = getAlgorithmSignupStartTime(startTime);
-    expect(signupStartTime.toISOString()).toEqual("2023-07-28T12:00:00.000Z");
+    expect(signupStartTime.toISOString()).toEqual(`${friday}T12:00:00.000Z`);
   });
 
   test("RPG starting at 18:00 should have signup starting at 15:00", () => {
-    const startTime = "2023-07-28T15:00:00.000Z";
+    const startTime = `${friday}T15:00:00.000Z`;
     const signupStartTime = getAlgorithmSignupStartTime(startTime);
-    expect(signupStartTime.toISOString()).toEqual("2023-07-28T12:00:00.000Z");
+    expect(signupStartTime.toISOString()).toEqual(`${friday}T12:00:00.000Z`);
   });
 
   test("RPG starting at 19:00 should have signup starting at 15:00", () => {
-    const startTime = "2023-07-28T16:00:00.000Z";
+    const startTime = `${friday}T16:00:00.000Z`;
     const signupStartTime = getAlgorithmSignupStartTime(startTime);
-    expect(signupStartTime.toISOString()).toEqual("2023-07-28T12:00:00.000Z");
+    expect(signupStartTime.toISOString()).toEqual(`${friday}T12:00:00.000Z`);
   });
 
   test("RPG starting at 20:00 should have signup starting at 16:00", () => {
-    const startTime = "2023-07-28T17:00:00.000Z";
+    const startTime = `${friday}T17:00:00.000Z`;
     const signupStartTime = getAlgorithmSignupStartTime(startTime);
-    expect(signupStartTime.toISOString()).toEqual("2023-07-28T13:00:00.000Z");
+    expect(signupStartTime.toISOString()).toEqual(`${friday}T13:00:00.000Z`);
   });
 
   test("RPG starting at 21:00 should have signup starting at 17:00", () => {
-    const startTime = "2023-07-28T18:00:00.000Z";
+    const startTime = `${friday}T18:00:00.000Z`;
     const signupStartTime = getAlgorithmSignupStartTime(startTime);
-    expect(signupStartTime.toISOString()).toEqual("2023-07-28T14:00:00.000Z");
+    expect(signupStartTime.toISOString()).toEqual(`${friday}T14:00:00.000Z`);
   });
 });
 
 describe(`Early algorithm signup`, () => {
   test("RPG starting at 09:00 should have signup starting at 22:00", () => {
-    const startTime = "2023-07-29T06:00:00.000Z";
+    const startTime = `${saturday}T06:00:00.000Z`;
     const signupStartTime = getAlgorithmSignupStartTime(startTime);
-    expect(signupStartTime.toISOString()).toEqual("2023-07-28T19:00:00.000Z");
+    expect(signupStartTime.toISOString()).toEqual(`${friday}T19:00:00.000Z`);
   });
 
   test("RPG starting at 10:00 should have signup starting at 22:00", () => {
-    const startTime = "2023-07-29T07:00:00.000Z";
+    const startTime = `${saturday}T07:00:00.000Z`;
     const signupStartTime = getAlgorithmSignupStartTime(startTime);
-    expect(signupStartTime.toISOString()).toEqual("2023-07-28T19:00:00.000Z");
+    expect(signupStartTime.toISOString()).toEqual(`${friday}T19:00:00.000Z`);
   });
 
   test("RPG starting at 11:00 should have signup starting at 07:00", () => {
-    const startTime = "2023-07-29T08:00:00.000Z";
+    const startTime = `${saturday}T08:00:00.000Z`;
     const signupStartTime = getAlgorithmSignupStartTime(startTime);
-    expect(signupStartTime.toISOString()).toEqual("2023-07-29T04:00:00.000Z");
+    expect(signupStartTime.toISOString()).toEqual(`${saturday}T04:00:00.000Z`);
   });
 
   test("RPG starting at 12:00 should have signup starting at 08:00", () => {
-    const startTime = "2023-07-29T09:00:00.000Z";
+    const startTime = `${saturday}T09:00:00.000Z`;
     const signupStartTime = getAlgorithmSignupStartTime(startTime);
-    expect(signupStartTime.toISOString()).toEqual("2023-07-29T05:00:00.000Z");
+    expect(signupStartTime.toISOString()).toEqual(`${saturday}T05:00:00.000Z`);
   });
 });
 
 describe(`Two phase direct signup`, () => {
   test("RPG starting at 15:00 should have signup starting at 15:00", () => {
-    const startTime = "2023-07-28T12:00:00.000Z";
+    const startTime = `${friday}T12:00:00.000Z`;
     const signupStartTime = getDirectSignupStartTime({
       ...testProgramItem,
       startTime,
     });
     expect(dayjs(signupStartTime).toISOString()).toEqual(
-      "2023-07-28T12:00:00.000Z",
+      `${friday}T12:00:00.000Z`,
     );
   });
 
   test("RPG starting at 16:00 should have signup starting at 15:00", () => {
-    const startTime = "2023-07-28T13:00:00.000Z";
+    const startTime = `${friday}T13:00:00.000Z`;
     const signupStartTime = getDirectSignupStartTime({
       ...testProgramItem,
       startTime,
     });
     expect(dayjs(signupStartTime).toISOString()).toEqual(
-      "2023-07-28T12:00:00.000Z",
+      `${friday}T12:00:00.000Z`,
     );
   });
 
   test("RPG starting at 17:00 should have signup starting at 15:00", () => {
-    const startTime = "2023-07-28T14:00:00.000Z";
+    const startTime = `${friday}T14:00:00.000Z`;
     const signupStartTime = getDirectSignupStartTime({
       ...testProgramItem,
       startTime,
     });
     expect(dayjs(signupStartTime).toISOString()).toEqual(
-      "2023-07-28T12:00:00.000Z",
+      `${friday}T12:00:00.000Z`,
     );
   });
 
   test("RPG starting at 18:00 should have signup starting at 16:15", () => {
-    const startTime = "2023-07-28T15:00:00.000Z";
+    const startTime = `${friday}T15:00:00.000Z`;
     const signupStartTime = getDirectSignupStartTime({
       ...testProgramItem,
       startTime,
     });
     expect(dayjs(signupStartTime).toISOString()).toEqual(
-      "2023-07-28T13:15:00.000Z",
+      `${friday}T13:15:00.000Z`,
     );
   });
 
   test("RPG starting at 19:00 should have signup starting at 17:15", () => {
-    const startTime = "2023-07-28T16:00:00.000Z";
+    const startTime = `${friday}T16:00:00.000Z`;
     const signupStartTime = getDirectSignupStartTime({
       ...testProgramItem,
       startTime,
     });
     expect(dayjs(signupStartTime).toISOString()).toEqual(
-      "2023-07-28T14:15:00.000Z",
+      `${friday}T14:15:00.000Z`,
     );
   });
 
   test("RPG starting at 20:00 should have signup starting at 18:15", () => {
-    const startTime = "2023-07-28T17:00:00.000Z";
+    const startTime = `${friday}T17:00:00.000Z`;
     const signupStartTime = getDirectSignupStartTime({
       ...testProgramItem,
       startTime,
     });
     expect(dayjs(signupStartTime).toISOString()).toEqual(
-      "2023-07-28T15:15:00.000Z",
+      `${friday}T15:15:00.000Z`,
     );
   });
 });
 
-describe(`Direct signup`, () => {
+describe(`Direct signup with signup windows`, () => {
   const testLarp = { ...testProgramItem, programType: ProgramType.LARP };
   const testLarp2 = { ...testProgramItem2, programType: ProgramType.LARP };
 
@@ -200,50 +205,135 @@ describe(`Direct signup`, () => {
   };
 
   test("Larp starting at Fri 15:00 should have signup starting at Fri 15:00", () => {
-    const startTime = "2023-07-28T12:00:00.000Z";
-    const signupTime = "2023-07-28T12:00:00.000Z";
+    const startTime = `${friday}T12:00:00.000Z`;
+    const signupTime = `${friday}T12:00:00.000Z`;
     assertSignupTime(startTime, signupTime);
   });
 
   test("Larp starting at Fri 16:00 should have signup starting at Fri 15:00", () => {
-    const startTime = "2023-07-28T13:00:00.000Z";
-    const signupTime = "2023-07-28T12:00:00.000Z";
+    const startTime = `${friday}T13:00:00.000Z`;
+    const signupTime = `${friday}T12:00:00.000Z`;
     assertSignupTime(startTime, signupTime);
   });
 
   test("Larp starting at Fri 17:00 should have signup starting at Fri 15:00", () => {
-    const startTime = "2023-07-28T14:00:00.000Z";
-    const signupTime = "2023-07-28T12:00:00.000Z";
+    const startTime = `${friday}T14:00:00.000Z`;
+    const signupTime = `${friday}T12:00:00.000Z`;
     assertSignupTime(startTime, signupTime);
   });
 
   test("Larp starting at Fri 18:00 should have signup starting at Fri 15:00", () => {
-    const startTime = "2023-07-28T15:00:00.000Z";
-    const signupTime = "2023-07-28T12:00:00.000Z";
+    const startTime = `${friday}T15:00:00.000Z`;
+    const signupTime = `${friday}T12:00:00.000Z`;
     assertSignupTime(startTime, signupTime);
   });
 
   test("Larp starting at Fri 19:00 should have signup starting at Fri 15:00", () => {
-    const startTime = "2023-07-28T16:00:00.000Z";
-    const signupTime = "2023-07-28T12:00:00.000Z";
+    const startTime = `${friday}T16:00:00.000Z`;
+    const signupTime = `${friday}T12:00:00.000Z`;
     assertSignupTime(startTime, signupTime);
   });
 
   test("Larp starting at Fri 20:00 should have signup starting at Fri 15:00", () => {
-    const startTime = "2023-07-28T17:00:00.000Z";
-    const signupTime = "2023-07-28T12:00:00.000Z";
+    const startTime = `${friday}T17:00:00.000Z`;
+    const signupTime = `${friday}T12:00:00.000Z`;
     assertSignupTime(startTime, signupTime);
   });
 
   test("Larp starting at Sat 20:00 should have signup starting at Sat 11:00", () => {
-    const startTime = "2023-07-29T17:00:00.000Z";
-    const signupTime = "2023-07-29T08:00:00.000Z";
+    const startTime = `${saturday}T17:00:00.000Z`;
+    const signupTime = `${saturday}T08:00:00.000Z`;
     assertSignupTime(startTime, signupTime);
   });
 
   test("Larp starting at Sun 12:00 should have signup starting at Sat 15:00", () => {
-    const startTime = "2023-07-30T15:00:00.000Z";
-    const signupTime = "2023-07-29T12:00:00.000Z";
+    const startTime = `${sunday}T15:00:00.000Z`;
+    const signupTime = `${saturday}T12:00:00.000Z`;
+    assertSignupTime(startTime, signupTime);
+  });
+});
+
+describe(`Direct signup with rolling signup`, () => {
+  const testWorkshop = {
+    ...testProgramItem,
+    programType: ProgramType.WORKSHOP,
+  };
+  const testWorkshop2 = {
+    ...testProgramItem2,
+    programType: ProgramType.WORKSHOP,
+  };
+
+  const assertSignupTime = (startTime: string, signupTime: string) => {
+    const signupStartTime = getDirectSignupStartTime({
+      ...testWorkshop,
+      startTime,
+    });
+    const signupStartTime2 = getDirectSignupStartTime({
+      ...testWorkshop2,
+      startTime,
+    });
+
+    expect(dayjs(signupStartTime).toISOString()).toEqual(signupTime);
+    expect(dayjs(signupStartTime2).toISOString()).toEqual(signupTime);
+  };
+
+  test("Workshop starting at Fri 15:00 should have signup starting at Fri 15:00", () => {
+    const startTime = `${friday}T12:00:00.000Z`;
+    const signupTime = `${friday}T12:00:00.000Z`;
+    assertSignupTime(startTime, signupTime);
+  });
+
+  test("Workshop starting at Fri 16:00 should have signup starting at Fri 15:00", () => {
+    const startTime = `${friday}T13:00:00.000Z`;
+    const signupTime = `${friday}T12:00:00.000Z`;
+    assertSignupTime(startTime, signupTime);
+  });
+
+  test("Workshop starting at Fri 17:00 should have signup starting at Fri 15:00", () => {
+    const startTime = `${friday}T14:00:00.000Z`;
+    const signupTime = `${friday}T12:00:00.000Z`;
+    assertSignupTime(startTime, signupTime);
+  });
+
+  test("Workshop starting at Fri 18:00 should have signup starting at Fri 15:00", () => {
+    const startTime = `${friday}T15:00:00.000Z`;
+    const signupTime = `${friday}T12:00:00.000Z`;
+    assertSignupTime(startTime, signupTime);
+  });
+
+  test("Workshop starting at Fri 19:00 should have signup starting at Fri 15:00", () => {
+    const startTime = `${friday}T16:00:00.000Z`;
+    const signupTime = `${friday}T12:00:00.000Z`;
+    assertSignupTime(startTime, signupTime);
+  });
+
+  test("Workshop starting at Fri 20:00 should have signup starting at Fri 16:00", () => {
+    const startTime = `${friday}T17:00:00.000Z`;
+    const signupTime = `${friday}T13:00:00.000Z`;
+    assertSignupTime(startTime, signupTime);
+  });
+
+  test("Workshop starting at Sat 11:00 should have signup starting at Fri 18:00", () => {
+    const startTime = `${saturday}T08:00:00.000Z`;
+    const signupTime = `${friday}T15:00:00.000Z`;
+    assertSignupTime(startTime, signupTime);
+  });
+
+  test("Workshop starting at Sat 12:00 should have signup starting at Sat 08:00", () => {
+    const startTime = `${saturday}T09:00:00.000Z`;
+    const signupTime = `${saturday}T05:00:00.000Z`;
+    assertSignupTime(startTime, signupTime);
+  });
+
+  test("Workshop starting at Sat 20:00 should have signup starting at Sat 16:00", () => {
+    const startTime = `${saturday}T17:00:00.000Z`;
+    const signupTime = `${saturday}T13:00:00.000Z`;
+    assertSignupTime(startTime, signupTime);
+  });
+
+  test("Workshop starting at Sun 11:00 should have signup starting at Sat 18:00", () => {
+    const startTime = `${sunday}T08:00:00.000Z`;
+    const signupTime = `${saturday}T15:00:00.000Z`;
     assertSignupTime(startTime, signupTime);
   });
 });

--- a/shared/utils/signupTimes.ts
+++ b/shared/utils/signupTimes.ts
@@ -81,7 +81,7 @@ export const getDirectSignupStartTime = (programItem: ProgramItem): Dayjs => {
     return directSignupStartWithPhaseGap;
   }
 
-  // ** DYNAMIC DIRECT SIGNUP **
+  // ** ROLLING DIRECT SIGNUP **
 
   if (rollingSignupStartProgramTypes.includes(programItem.programType)) {
     // Signup starts 4 hours before program item start time

--- a/shared/utils/signupTimes.ts
+++ b/shared/utils/signupTimes.ts
@@ -6,7 +6,7 @@ import { TIMEZONE } from "shared/utils/initializeDayjs";
 export const getAlgorithmSignupStartTime = (startTime: string): Dayjs => {
   const { conventionStartTime, PRE_SIGNUP_START } = config.shared();
 
-  // Set timezone here because hour comparison and setting hour value
+  // Set timezone because hour comparison and setting hour value
   const timezoneStartTime = dayjs(startTime)
     .tz(TIMEZONE)
     .subtract(PRE_SIGNUP_START, "minutes");
@@ -35,10 +35,12 @@ export const getDirectSignupStartTime = (programItem: ProgramItem): Dayjs => {
     DIRECT_SIGNUP_START,
     PHASE_GAP,
     directSignupWindows,
+    rollingSignupStartProgramTypes,
     directSignupAlwaysOpenIds,
     twoPhaseSignupProgramTypes,
   } = config.shared();
 
+  // ** SIGNUP ALWAYS OPEN **
   const signupAlwaysOpen = directSignupAlwaysOpenIds.includes(
     programItem.programItemId,
   );
@@ -46,6 +48,8 @@ export const getDirectSignupStartTime = (programItem: ProgramItem): Dayjs => {
   if (signupAlwaysOpen) {
     return dayjs(conventionStartTime);
   }
+
+  // ** TWO PHASE SIGNUPS **
 
   // "twoPhaseSignupProgramTypes" signup times are configured with DIRECT_SIGNUP_START
   if (twoPhaseSignupProgramTypes.includes(programItem.programType)) {
@@ -76,6 +80,31 @@ export const getDirectSignupStartTime = (programItem: ProgramItem): Dayjs => {
 
     return directSignupStartWithPhaseGap;
   }
+
+  // ** DYNAMIC DIRECT SIGNUP **
+
+  if (rollingSignupStartProgramTypes.includes(programItem.programType)) {
+    // Signup starts 4 hours before program item start time
+    const rollingStartTime = dayjs(programItem.startTime).subtract(4, "hours");
+
+    // Earliest start time is convention start time
+    if (rollingStartTime.isBefore(dayjs(conventionStartTime))) {
+      return dayjs(conventionStartTime);
+    }
+
+    // If program item starts before 12:00, signup starts 18:00 previous day
+
+    // Set timezone because hour comparison and setting hour value
+    const timezoneStartTime = dayjs(programItem.startTime).tz(TIMEZONE);
+    const startTimeIsTooEarly = timezoneStartTime.hour() < 12;
+    if (startTimeIsTooEarly) {
+      return timezoneStartTime.subtract(1, "day").hour(18);
+    }
+
+    return rollingStartTime;
+  }
+
+  // ** DIRECT SIGNUP WINDOWS **
 
   // Other program types use "directSignupWindows" config
   const signupWindowsForProgramType = directSignupWindows


### PR DESCRIPTION
* Set workshop signups to start 4h before program item
* If workshop starts before 12:00, signup starts previous day at 18:00