### PR TITLE
Add expand sections to about pages

### DIFF
--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -481,6 +481,8 @@ export const translationEN = {
     instructions: "Help",
     about: "About",
     faq: "FAQ",
+    showMore: "Show more",
+    showLess: "Show less",
   },
   profileView: {
     profileTab: "Profile",

--- a/client/src/locales/fi.ts
+++ b/client/src/locales/fi.ts
@@ -483,6 +483,8 @@ export const translationFI = {
     instructions: "Ohjeet",
     about: "Tietoja",
     faq: "UKK",
+    showMore: "Näytä lisää",
+    showLess: "Näytä vähemmän",
   },
   profileView: {
     profileTab: "Profiili",

--- a/client/src/markdown/KonstiFaq.mdx
+++ b/client/src/markdown/KonstiFaq.mdx
@@ -15,11 +15,11 @@ import { Expand } from "./components/Expand";
 
 <Expand>
 <Fi>
-### Mistä saan apua Konstin käyttöön?
+## Mistä saan apua Konstin käyttöön?
 </Fi>
 
 <En>
-### I need help with the Konsti app, who can I ask?
+## I need help with the Konsti app, who can I ask?
 </En>
 
 <Fi>
@@ -59,11 +59,11 @@ If you have any questions about the Konsti app or how to use it, do not hesitate
 
 <Expand>
 <Fi>
-### Kuinka aloitan Konstin käytön?
+## Kuinka aloitan Konstin käytön?
 </Fi>
 
 <En>
-### I want to start using Konsti - where do I begin?
+## I want to start using Konsti - where do I begin?
 </En>
 
 <Fi>
@@ -111,11 +111,11 @@ Please note that Konsti accounts from previous events are no longer in use.
 <Ropecon>
 <Expand>
 <Fi>
-### Mistä saan rekisteröintikoodin?
+## Mistä saan rekisteröintikoodin?
 </Fi>
 
 <En>
-### Where can I get a registration code?
+## Where can I get a registration code?
 </En>
 
 <Fi>
@@ -131,7 +131,7 @@ Registration codes can be picked up at either the Gaming Desk (Hall 3), at the L
 
 <Expand>
 <Fi>
-### Paljonko kello on?
+## Paljonko kello on?
 </Fi>
 <Fi>
 Konstin kaikki kellonajat käyttävät Suomen aikavyöhykettä (<FinnishTimezone/>).
@@ -142,7 +142,7 @@ Konstin kaikki kellonajat käyttävät Suomen aikavyöhykettä (<FinnishTimezone
 </Fi>
 
 <En>
-### What's the time?
+## What's the time?
 </En>
 
 <En>
@@ -156,11 +156,11 @@ All times in Konsti use Finland's timezone (<FinnishTimezone/>).
 
 <Expand>
 <Fi>
-### Kuinka vaihdan salasanani?
+## Kuinka vaihdan salasanani?
 </Fi>
 
 <En>
-### How do I change my password?
+## How do I change my password?
 </En>
 
 <Fi>
@@ -204,11 +204,11 @@ If you lost your password before signing up for any program, you can just pick u
 
 <Expand>
 <Fi>
-### Minulla ei ole mobiililaitetta, kuinka käytän Konstia tapahtuman aikana?
+## Minulla ei ole mobiililaitetta, kuinka käytän Konstia tapahtuman aikana?
 </Fi>
 
 <En>
-### I do not have a mobile device, how do I use Konsti during the event?
+## I do not have a mobile device, how do I use Konsti during the event?
 </En>
 
 <Fi>
@@ -242,11 +242,11 @@ There are shared computers on the Programme Desk that you can use Konsti with. J
 
 <Expand>
 <Fi>
-### En löydä etsimääni ohjelmanumeroa Konstista?
+## En löydä etsimääni ohjelmanumeroa Konstista?
 </Fi>
 
 <En>
-### Why can't I find a certain program item in Konsti?
+## Why can't I find a certain program item in Konsti?
 </En>
 
 <Fi>
@@ -297,11 +297,11 @@ If you still cannot find the program item you are looking for, it is possible th
 <SignupLottery>
 <Expand>
 <Fi>
-### Miksi en voi ilmoittautua haluamaani ohjelmanumeroon, vaikka se on Konstissa?
+## Miksi en voi ilmoittautua haluamaani ohjelmanumeroon, vaikka se on Konstissa?
 </Fi>
 
 <En>
-### Why can I not sign up for a program item even though it's visible in Konsti?
+## Why can I not sign up for a program item even though it's visible in Konsti?
 </En>
 
 <Fi>
@@ -341,11 +341,11 @@ Please note that signing up for a program item in one program type does not prev
 </En>
 
 <Fi>
-### Miksi en pysty liittymään ryhmään/luomaan ryhmää?
+## Miksi en pysty liittymään ryhmään/luomaan ryhmää?
 </Fi>
 
 <En>
-### Why can I not create or join a group?
+## Why can I not create or join a group?
 </En>
 
 <Fi>
@@ -360,11 +360,11 @@ You cannot create a new group or join a group if you have already signed up for 
 
 <Expand>
 <Fi>
-### Voinko ilmoittautua useampaan yhtäaikaiseen ohjelmanumeroon?
+## Voinko ilmoittautua useampaan yhtäaikaiseen ohjelmanumeroon?
 </Fi>
 
 <En>
-### Can I sign up for multiple simultaneous program item?
+## Can I sign up for multiple simultaneous program item?
 </En>
 
 <Fi>
@@ -391,11 +391,11 @@ Additionally, since signing up for a program item in one programme type does not
 <SignupLottery>
 <Expand>
 <Fi>
-### Miksen päässytkään pöytäroolipeliin, johon ilmoittauduin?
+## Miksen päässytkään pöytäroolipeliin, johon ilmoittauduin?
 </Fi>
 
 <En>
-### Why wasn't I signed up for the role-playing game I tried to sign up for?
+## Why wasn't I signed up for the role-playing game I tried to sign up for?
 </En>
 
 <Fi>
@@ -410,11 +410,11 @@ When signing up for role-playing games using the Konsti app, there is first a lo
 
 <Expand>
 <Fi>
-### En pääsekään ohjelmanumeroon johon ilmoittauduin, mitä teen?
+## En pääsekään ohjelmanumeroon johon ilmoittauduin, mitä teen?
 </Fi>
 
 <En>
-### I can't make it to the program item I signed up for, what do I do now?
+## I can't make it to the program item I signed up for, what do I do now?
 </En>
 
 <Fi>

--- a/client/src/markdown/KonstiFaq.mdx
+++ b/client/src/markdown/KonstiFaq.mdx
@@ -11,13 +11,15 @@ import { CurrentTimezone } from "./components/CurrentTimezone";
 import { FinnishTimezone } from "./components/FinnishTimezone";
 import { CurrentTime } from "./components/CurrentTime";
 import { FinnishTime } from "./components/FinnishTime";
+import { Expand } from "./components/Expand";
 
+<Expand>
 <Fi>
-## Mistä saan apua Konstin käyttöön?
+### Mistä saan apua Konstin käyttöön?
 </Fi>
 
 <En>
-## I need help with the Konsti app, who can I ask?
+### I need help with the Konsti app, who can I ask?
 </En>
 
 <Fi>
@@ -53,13 +55,15 @@ Our volunteers at the Programme Desk will gladly assist you and help you sign up
 If you have any questions about the Konsti app or how to use it, do not hesitate to ask them for help!
 </Solmukohta>
 </En>
+</Expand>
 
+<Expand>
 <Fi>
-## Kuinka aloitan Konstin käytön?
+### Kuinka aloitan Konstin käytön?
 </Fi>
 
 <En>
-## I want to start using Konsti - where do I begin?
+### I want to start using Konsti - where do I begin?
 </En>
 
 <Fi>
@@ -102,29 +106,34 @@ Huomaathan, että aikaisemmissa tapahtumissa käytössä olleet Konsti-käyttäj
 <En>
 Please note that Konsti accounts from previous events are no longer in use.
 </En>
+</Expand>
 
 <Ropecon>
+<Expand>
 <Fi>
-## Mistä saan rekisteröintikoodin?
+### Mistä saan rekisteröintikoodin?
 </Fi>
 
 <En>
-## Where can I get a registration code?
+### Where can I get a registration code?
 </En>
 
 <Fi>
-Rekisteröintikoodeja saa Ropeconissa Pelitiskiltä (Halli 5) sekä rope/larp-tiskiltä ja Infosta (Pääaula, Eteläinen sisäänkäynti).
+Rekisteröintikoodeja saa Ropeconissa Pelitiskiltä (Halli 3) sekä rope/larp-tiskiltä ja Infosta (Pääaula, Eteläinen sisäänkäynti).
 Käyttäjätilin voi siis käytännössä luoda vasta tapahtumassa paikan päällä.
 </Fi>
 
 <En>
-Registration codes can be picked up at either the Gaming Desk (Hall 5), at the Larp & RPG Desk or at the Info desk (both in the Southern Entrance lobby). This means that you cannot create a new account before arriving to the event.
+Registration codes can be picked up at either the Gaming Desk (Hall 3), at the Larp & RPG Desk or at the Info desk (both in the Southern Entrance lobby). This means that you cannot create a new account before arriving to the event.
 </En>
+</Expand>
 </Ropecon>
 
+<Expand>
 <Fi>
-## Paljonko kello on?
-
+### Paljonko kello on?
+</Fi>
+<Fi>
 Konstin kaikki kellonajat käyttävät Suomen aikavyöhykettä (<FinnishTimezone/>).
 
 - Paikallinen aika: <CurrentTime/> (<CurrentTimezone/>)
@@ -133,21 +142,25 @@ Konstin kaikki kellonajat käyttävät Suomen aikavyöhykettä (<FinnishTimezone
 </Fi>
 
 <En>
-## What's the time?
+### What's the time?
+</En>
 
+<En>
 All times in Konsti use Finland's timezone (<FinnishTimezone/>).
 
 - Local time: <CurrentTime/> (<CurrentTimezone/>)
 - Finnish time: <FinnishTime/> (<FinnishTimezone/>)
 
 </En>
+</Expand>
 
+<Expand>
 <Fi>
-## Kuinka vaihdan salasanani?
+### Kuinka vaihdan salasanani?
 </Fi>
 
 <En>
-## How do I change my password?
+### How do I change my password?
 </En>
 
 <Fi>
@@ -187,13 +200,15 @@ Jos et ollut ehtinyt vielä ilmoittautua yhteenkään peliin, voit huoletta hake
 If you lost your password before signing up for any program, you can just pick up another registration code and create a new account.
 </En>
 </Ropecon>
+</Expand>
 
+<Expand>
 <Fi>
-## Minulla ei ole mobiililaitetta, kuinka käytän Konstia tapahtuman aikana?
+### Minulla ei ole mobiililaitetta, kuinka käytän Konstia tapahtuman aikana?
 </Fi>
 
 <En>
-## I do not have a mobile device, how do I use Konsti during the event?
+### I do not have a mobile device, how do I use Konsti during the event?
 </En>
 
 <Fi>
@@ -223,13 +238,15 @@ There are shared computers on the RPG Desk that you can use Konsti with. Just re
 There are shared computers on the Programme Desk that you can use Konsti with. Just remember to log out when you are done!
 </Solmukohta>
 </En>
+</Expand>
 
+<Expand>
 <Fi>
-## En löydä etsimääni ohjelmanumeroa Konstista?
+### En löydä etsimääni ohjelmanumeroa Konstista?
 </Fi>
 
 <En>
-## Why can't I find a certain program item in Konsti?
+### Why can't I find a certain program item in Konsti?
 </En>
 
 <Fi>
@@ -275,14 +292,16 @@ If you still cannot find the program item you are looking for, it is possible th
 If you still cannot find the program item you are looking for, it is possible that the sign-up process for that particular program item is not done via the Konsti app but in some other way. If you are unsure, you can always confirm the sign-up method for a certain program item from the RPG Desk.
 </Hitpoint>
 </En>
+</Expand>
 
 <SignupLottery>
+<Expand>
 <Fi>
-## Miksi en voi ilmoittautua haluamaani ohjelmanumeroon, vaikka se on Konstissa?
+### Miksi en voi ilmoittautua haluamaani ohjelmanumeroon, vaikka se on Konstissa?
 </Fi>
 
 <En>
-## Why can I not sign up for a program item even though it's visible in Konsti?
+### Why can I not sign up for a program item even though it's visible in Konsti?
 </En>
 
 <Fi>
@@ -322,11 +341,11 @@ Please note that signing up for a program item in one program type does not prev
 </En>
 
 <Fi>
-## Miksi en pysty liittymään ryhmään/luomaan ryhmää?
+### Miksi en pysty liittymään ryhmään/luomaan ryhmää?
 </Fi>
 
 <En>
-## Why can I not create or join a group?
+### Why can I not create or join a group?
 </En>
 
 <Fi>
@@ -336,14 +355,16 @@ Jos sinulla on jo suoria ilmoittautumisia peleihin, et voi luoda uutta ryhmää 
 <En>
 You cannot create a new group or join a group if you have already signed up for games. You can check which games are preventing you from creating or joining a group in the <Link to={'/profile/group'}>Group view</Link>.
 </En>
+</Expand>
 </SignupLottery>
 
+<Expand>
 <Fi>
-## Voinko ilmoittautua useampaan yhtäaikaiseen ohjelmanumeroon?
+### Voinko ilmoittautua useampaan yhtäaikaiseen ohjelmanumeroon?
 </Fi>
 
 <En>
-## Can I sign up for multiple simultaneous program item?
+### Can I sign up for multiple simultaneous program item?
 </En>
 
 <Fi>
@@ -365,14 +386,16 @@ Koska yhden ohjelmatyypin ohjelmanumeroon ilmoittautuminen ei estä toisen ohjel
 Additionally, since signing up for a program item in one programme type does not prevent the user from signing up for a program item in another programme type in the same time slot, it is technically possible to accidentally sign up for e.g. both a tabletop role-playing game and a larp held at the same time. Please make sure that you only sign up for one program item per slot and that you can actually attend the program items you sign up for!
 </Ropecon>
 </En>
+</Expand>
 
 <SignupLottery>
+<Expand>
 <Fi>
-## Miksen päässytkään pöytäroolipeliin, johon ilmoittauduin?
+### Miksen päässytkään pöytäroolipeliin, johon ilmoittauduin?
 </Fi>
 
 <En>
-## Why wasn't I signed up for the role-playing game I tried to sign up for?
+### Why wasn't I signed up for the role-playing game I tried to sign up for?
 </En>
 
 <Fi>
@@ -382,14 +405,16 @@ Roolipelien kohdalla käytössä on kaksivaiheinen ilmoittautumissysteemi, jossa
 <En>
 When signing up for role-playing games using the Konsti app, there is first a lottery sign-up phase where the user signs up for up to three games and the algorithm assigns users into games. However, a lottery sign-up does not necessarily guarantee a place in any of the games you have chosen. It simply means that you have signed up to take part in the lottery executed by the algorithm. When the initial algorithmic placement is over, there can sometimes unfortunately be some users that have not secured a spot in a game of their choice - this can sometimes be the case, especially with very popular games. However, there is still a chance to find a game for the upcoming time slot and sign up for it during the direct sign-up phase.
 </En>
+</Expand>
 </SignupLottery>
 
+<Expand>
 <Fi>
-## En pääsekään ohjelmanumeroon johon ilmoittauduin, mitä teen?
+### En pääsekään ohjelmanumeroon johon ilmoittauduin, mitä teen?
 </Fi>
 
 <En>
-## I can't make it to the program item I signed up for, what do I do now?
+### I can't make it to the program item I signed up for, what do I do now?
 </En>
 
 <Fi>
@@ -399,3 +424,4 @@ Jos et jostain syystä pääsekään ohjelmanumeroon, johon olet jo ilmoittautun
 <En>
 If you cannot make it to the program item you have signed up for via the Konsti app and the sign-up period is still ongoing, please make sure to cancel your sign-up as soon as possible. This way someone else will have a chance to sign up for the program item and fill your seat!
 </En>
+</Expand>

--- a/client/src/markdown/KonstiInstructions.mdx
+++ b/client/src/markdown/KonstiInstructions.mdx
@@ -9,6 +9,7 @@ import { LoginLocal } from "./components/LoginLocal";
 import { SignupLottery } from "./components/SignupLottery";
 import { Expand } from "./components/Expand";
 
+<Expand>
 <Fi>
 ## Mihin Konstia käytetään?
 </Fi>
@@ -49,7 +50,9 @@ The RPG Desk will help you with using Konsti. The desks also have shared compute
 
 </Hitpoint>
 </En>
+</Expand>
 
+<Expand>
 <Fi>
 ## Miten Konstia käytetään?
 </Fi>
@@ -74,8 +77,6 @@ Konsti is a web application that can be accessed through any web browser on your
 <En>
 You can browse the <Link to={'/program/list'}>program list</Link> without logging in, but to register for programs, a user account is required.
 </En>
-
-<Expand>
 
 <Fi>
 ### Tilin luominen ja sisäänkirjautuminen
@@ -131,9 +132,7 @@ to change your password. The code is visible in Konsti after you first log in. L
 can see it on the <Link to={'/profile/profile'}>profile page</Link>.
 </Ropecon>
 </En>
-</Expand>
 
-<Expand>
 <Fi>
 ### Ohjelman selaaminen
 </Fi>
@@ -175,9 +174,7 @@ For program items that use lottery sign-up, the number will not change until the
 period is over and the algorithm has allocated users to program items.
 </SignupLottery>
 </En>
-</Expand>
 
-<Expand>
 <Fi>
 ### Suosikkiohjelmanumerot
 </Fi>
@@ -197,6 +194,7 @@ Favoriting program items is an excellent way to keep track of program items you 
 </En>
 </Expand>
 
+<Expand>
 <Fi>
 ## Ilmoittautuminen
 </Fi>
@@ -242,7 +240,6 @@ Konsti will show you a notification if you get a spot in a game in the lottery. 
 </SignupLottery>
 
 <Ropecon>
-<Expand>
 <Fi>
 ### Pyöröoviohjelmanumerot
 </Fi>
@@ -259,10 +256,10 @@ ilmoittautua normaalisti, mutta kun ohjelmanumero alkaa, se näkyy koko kestoaik
 <En>
 Revolving door program items are program items where participants can freely join and leave. The first participants can sign up for these program items as usual, but after the revolving door program item begin, they are displayed in the program list for their whole duration.
 </En>
-</Expand>
 </Ropecon>
+</Expand>
 
-<Solmukohta not>
+<Expand>
 <Fi>
 ## Roolipeleihin ilmoittautuminen
 </Fi>
@@ -303,7 +300,6 @@ itseään kiinnostavasta pelistä niin kauan, kun siinä on vielä tilaa. Suorai
 <En>
 After the initial placements and the 15-minute intermission period, the direct sign-up phase begins. During the last 1h 45 min before the game is set to begin, you can sign up for a game as long as there is still room for new attendees. You do not need to participate in the lottery sign-up phase to be able to sign up during the direct sign-up period.
 </En>
-</Solmukohta>
 
 <Fi>
 <Ropecon>
@@ -324,7 +320,6 @@ The first games of the convention only have the direct sign-up phase since there
 </En>
 
 <SignupLottery>
-<Expand>
 <Fi>
 ### Ryhmät
 </Fi>
@@ -367,10 +362,11 @@ Ryhmä-näkymässä listataan ne pelit, jotka estävät ryhmän perustamisen tai
 If you already have direct sign-ups to games, you can't create a new group or join an
 existing one. These sign-ups will be shown on the group page.
 </En>
-</Expand>
 </SignupLottery>
+</Expand>
 
 <Ropecon>
+<Expand>
 <Fi>
 ## Larppeihin ilmoittautuminen
 </Fi>
@@ -398,7 +394,6 @@ larps at the Larp & RPG Desk, because the players may have to, for example, sele
 a character during sign-up.
 </En>
 
-<Expand>
 <Fi>
 ### Larppien ilmoittautumisten avautuminen
 </Fi>
@@ -422,6 +417,7 @@ a character during sign-up.
 </En>
 </Expand>
 
+<Expand>
 <Fi>
 ## Turnauksiin ilmoittautuminen
 </Fi>
@@ -442,7 +438,6 @@ may not use Konsti for signing up. If you can't find a tournament in Konsti and 
 how to sign up, you can ask for help at the game desk.
 </En>
 
-<Expand>
 <Fi>
 ### Turnausilmoittautumisten aikataulu
 </Fi>
@@ -462,9 +457,7 @@ how to sign up, you can ask for help at the game desk.
 - Saturday's tournaments: Friday 6PM
 - Sunday's tournaments: Saturday 6PM
 </En>
-</Expand>
 
-<Expand>
 <Fi>
 ### Yhteystietojen kysyminen
 </Fi>
@@ -487,6 +480,7 @@ contact information to tournament organizers.
 </En>
 </Expand>
 
+<Expand>
 <Fi>
 ## Työpajoihin ilmoittautuminen
 </Fi>
@@ -503,7 +497,6 @@ Työpajoihin ilmoittaudutaan suoraan eli paikat täytetään ilmoittautumisjärj
 Workshops use direct signup and seats are reserved in signup order.
 </En>
 
-<Expand>
 <Fi>
 ### Työpajailmoittautumisten aikataulu
 </Fi>
@@ -523,6 +516,7 @@ Workshops use direct signup and seats are reserved in signup order.
 </En>
 </Expand>
 
+<Expand>
 <Fi>
 ## Muuhun ohjelmaan ilmoittautuminen
 </Fi>
@@ -539,7 +533,6 @@ Muuhun ohjelmaan ilmoittaudutaan suoraan eli paikat täytetään ilmoittautumisj
 Other program items use direct signup and seats are reserved in signup order.
 </En>
 
-<Expand>
 <Fi>
 ### Muun ohjelman ilmoittautumisten aikataulu
 </Fi>
@@ -558,5 +551,4 @@ Other program items use direct signup and seats are reserved in signup order.
 - Except if the program item begins before 12 PM, then registration opens the previous day at 6 PM.
 </En>
 </Expand>
-
 </Ropecon>

--- a/client/src/markdown/KonstiInstructions.mdx
+++ b/client/src/markdown/KonstiInstructions.mdx
@@ -7,12 +7,21 @@ import { Solmukohta } from "./components/Solmukohta";
 import { LoginKompassi } from "./components/LoginKompassi";
 import { LoginLocal } from "./components/LoginLocal";
 import { SignupLottery } from "./components/SignupLottery";
+import { Expand } from "./components/Expand";
+
+<Fi>
+## Mihin Konstia käytetään?
+</Fi>
+
+<En>
+## For what is Konsti used?
+</En>
 
 <Fi>
 <Ropecon>
 Konstin kautta voi ilmoittautua pöytäroolipeleihin, larppeihin, turnauksiin, työpajoihin ja joihinkin muihin ohjelmanumeroihin.
 
-Konstin käytössä auttavat Pelitiski (Halli 5) ja Larp- ja Roolipelitiski (eteläisen sisäänkäynnin aula).
+Konstin käytössä auttavat Pelitiski (Halli 3) ja Larp- ja Roolipelitiski (eteläisen sisäänkäynnin aula).
 Tiskeillä on myös tietokoneita, joilla Konstia voi käyttää.
 
 </Ropecon>
@@ -29,7 +38,7 @@ Konstin käytössä auttaa roolipelitiski. Tiskillä on myös tietokoneita, joil
 <Ropecon>
 Konsti is used to sign up for role-playing games, larps, tournaments, workshops and some other program items.
 
-The Gaming Desk (Hall 5) and the Larp & RPG Desk (southern entrance lobby) will help you with using Konsti. The desks also have shared computers for using Konsti.
+The Gaming Desk (Hall 3) and the Larp & RPG Desk (southern entrance lobby) will help you with using Konsti. The desks also have shared computers for using Konsti.
 
 </Ropecon>
 
@@ -66,6 +75,8 @@ Konsti is a web application that can be accessed through any web browser on your
 You can browse the <Link to={'/program/list'}>program list</Link> without logging in, but to register for programs, a user account is required.
 </En>
 
+<Expand>
+
 <Fi>
 ### Tilin luominen ja sisäänkirjautuminen
 </Fi>
@@ -78,7 +89,7 @@ You can browse the <Link to={'/program/list'}>program list</Link> without loggin
 Aikaisempien tapahtumien Konsti-käyttäjätilit eivät ole enää käytössä, vaan sinun on luotava uusi tili tapahtumalle {props.conventionName} {props.conventionYear}.
 
 <LoginLocal>
-Uuden käyttäjätilin luomiseen tarvitset rekisteröintikoodin, joita on saatavilla Pelitiskiltä (Halli 5), Larp- ja Roolipelitiskiltä tai Infosta (molemmat pääaulassa, eteläisen sisäänkäynnin luona).
+Uuden käyttäjätilin luomiseen tarvitset rekisteröintikoodin, joita on saatavilla Pelitiskiltä (Halli 3), Larp- ja Roolipelitiskiltä tai Infosta (molemmat pääaulassa, eteläisen sisäänkäynnin luona).
 </LoginLocal>
 
 <LoginKompassi>
@@ -94,7 +105,7 @@ Konsti accounts from previous events have been removed, so you will need to crea
 
 <LoginLocal>
 For creating an account, you will need a registration code, which you can get from the
-Gaming Desk (Hall 5), the Larp & RPG Desk or the Info Desk (both in the southern entrance lobby).
+Gaming Desk (Hall 3), the Larp & RPG Desk or the Info Desk (both in the southern entrance lobby).
 </LoginLocal>
 
 <LoginKompassi>
@@ -120,7 +131,9 @@ to change your password. The code is visible in Konsti after you first log in. L
 can see it on the <Link to={'/profile/profile'}>profile page</Link>.
 </Ropecon>
 </En>
+</Expand>
 
+<Expand>
 <Fi>
 ### Ohjelman selaaminen
 </Fi>
@@ -162,7 +175,9 @@ For program items that use lottery sign-up, the number will not change until the
 period is over and the algorithm has allocated users to program items.
 </SignupLottery>
 </En>
+</Expand>
 
+<Expand>
 <Fi>
 ### Suosikkiohjelmanumerot
 </Fi>
@@ -180,6 +195,7 @@ ohjelmanumerot löydät <Link to={'/program/myprogram'}>Oma ohjelmani</Link> -n�
 <En>
 Favoriting program items is an excellent way to keep track of program items you find interesting. You can add a program item to your favorites by clicking on the heart icon in the upper right corner of the program item's info card. You can find your favorites in the <Link to={'/program/myprogram'}>My Program view</Link>.
 </En>
+</Expand>
 
 <Fi>
 ## Ilmoittautuminen
@@ -224,6 +240,27 @@ Jos pääset arvonnassa peliin, Konsti näyttää sinulle tästä ilmoituksen. N
 Konsti will show you a notification if you get a spot in a game in the lottery. You can also view these notifications on the <Link to={'/notifications'}>Notifications</Link> page. You can see all your sign-up results on the <Link to={'/program/myprogram'}>My Program page</Link> and all sign-ups to all program items on the <Link to={'/results'}>Sign-up Results</Link> page.
 </En>
 </SignupLottery>
+
+<Ropecon>
+<Expand>
+<Fi>
+### Pyöröoviohjelmanumerot
+</Fi>
+
+<En>
+### Revolving door program items
+</En>
+
+<Fi>
+Pyöröoviohjelmanumeroissa osallistujat voivat lähteä ohjelmanumerosta ja tulla siihen mukaan kesken. Pyöröoviohjelmanumeron alkuun voi
+ilmoittautua normaalisti, mutta kun ohjelmanumero alkaa, se näkyy koko kestoaikansa Konstin ilmottautumissivulla.
+</Fi>
+
+<En>
+Revolving door program items are program items where participants can freely join and leave. The first participants can sign up for these program items as usual, but after the revolving door program item begin, they are displayed in the program list for their whole duration.
+</En>
+</Expand>
+</Ropecon>
 
 <Solmukohta not>
 <Fi>
@@ -286,26 +323,8 @@ The first games of the convention only have the direct sign-up phase since there
 </Hitpoint>
 </En>
 
-<Ropecon>
-<Fi>
-### Pyöröovipelit
-</Fi>
-
-<En>
-### Revolving door program items
-</En>
-
-<Fi>
-Pyöröoviohjelmanumeroissa osallistujat voivat lähteä ohjelmanumerosta ja tulla siihen mukaan kesken. Pyöröoviohjelmanumeron alkuun voi
-ilmoittautua normaalisti, mutta kun ohjelmanumero alkaa, se näkyy koko kestoaikansa Konstin ilmottautumissivulla.
-</Fi>
-
-<En>
-Revolving door program items are program items where participants can freely join and leave. The first participants can sign up for these program items as usual, but after the revolving door program item begin, they are displayed in the program list for their whole duration.
-</En>
-</Ropecon>
-
 <SignupLottery>
+<Expand>
 <Fi>
 ### Ryhmät
 </Fi>
@@ -317,7 +336,7 @@ Revolving door program items are program items where participants can freely joi
 <Fi>
 Roolipeleihin voi ilmoittautua myös ryhmänä. Silloin arvonta-algoritmi sijoittaa kaikki ryhmän jäsenet samaan peliin
 (sikäli kun arpaonni suosii silloin kun ilmoittautuneita on enemmän kuin paikkoja). Voit luoda ryhmän <Link to={'/profile/group'}>Ryhmä-näkymässä</Link>.
-Samassa näkymässä voit myös liittyä olemassa olevaan ryhmään. Tätä varten tarvitset ryhmän perustajalta rekisteröitymiskoodin.
+Samassa näkymässä voit myös liittyä olemassa olevaan ryhmään. Tätä varten tarvitset ryhmän perustajalta liittymiskoodin, jonka näkee ryhmän luomisen jälkeen.
 </Fi>
 
 <En>
@@ -326,8 +345,8 @@ sign-ups than places, it is of course possible that the group will not get a spo
 game at all.
 
 You can create a group on the <Link to={'/profile/group'}>group page</Link>. There, you can also join an
-existing group, for which you will need a registration code from the person who created
-the group. Only the group creator can sign up the group to games.
+existing group, for which you will need a group code from the person who created
+the group. The code is available after the group is creted. Only the group creator can sign up the group to games.
 
 </En>
 
@@ -348,6 +367,7 @@ Ryhmä-näkymässä listataan ne pelit, jotka estävät ryhmän perustamisen tai
 If you already have direct sign-ups to games, you can't create a new group or join an
 existing one. These sign-ups will be shown on the group page.
 </En>
+</Expand>
 </SignupLottery>
 
 <Ropecon>
@@ -360,12 +380,11 @@ existing one. These sign-ups will be shown on the group page.
 </En>
 
 <Fi>
-Roolipeleistä poiketen larppien ilmoittautuminen on yksivaiheinen eikä sisällä arvontaa,
-vaan larpit täytetään ilmoittautumisjärjestyksessä (suorailmoittautuminen).
+Larppeihin ilmoittaudutaan suoraan eli paikat täytetään ilmoittautumisjärjestyksessä.
 </Fi>
 
 <En>
-Unlike tabletop rgps, larp sign-ups do not use a lottery and only contain one phase.
+Larps use direct signup and seats are reserved in signup order.
 </En>
 
 <Fi>
@@ -379,6 +398,7 @@ larps at the Larp & RPG Desk, because the players may have to, for example, sele
 a character during sign-up.
 </En>
 
+<Expand>
 <Fi>
 ### Larppien ilmoittautumisten avautuminen
 </Fi>
@@ -400,6 +420,7 @@ a character during sign-up.
 - Larps starting later on Saturday: Saturday 11AM
 - Larps on Sunday: Saturday 3PM
 </En>
+</Expand>
 
 <Fi>
 ## Turnauksiin ilmoittautuminen
@@ -410,23 +431,24 @@ a character during sign-up.
 </En>
 
 <Fi>
-Konstissa turnausilmoittautuminen on myös yksivaiheinen eli paikat täytetään ilmoittautumisjärjestyksessä. Kaikkien
+Turnauksiin ilmoittaudutaan suoraan eli paikat täytetään ilmoittautumisjärjestyksessä. Kaikkien
 turnausten ilmoittautuminen ei välttämättä tapahdu Konstin kautta. Jos etsimääsi turnausta ei löydy Konstista etkä
 tiedä, miten ilmoittautua siihen, voit kysyä neuvoa Pelitiskiltä.
 </Fi>
 
 <En>
-Tournament sign-ups also do not use a lottery and only contain one phase. Some tournaments
+Tournaments use direct signup and seats are reserved in signup order. Some tournaments
 may not use Konsti for signing up. If you can't find a tournament in Konsti and don't know
 how to sign up, you can ask for help at the game desk.
 </En>
 
+<Expand>
 <Fi>
-### Turnausilmoittautumisten avautuminen
+### Turnausilmoittautumisten aikataulu
 </Fi>
 
 <En>
-### Sign-up period start times for tournaments
+### Tournament sign-up schedule
 </En>
 
 <Fi>
@@ -440,7 +462,9 @@ how to sign up, you can ask for help at the game desk.
 - Saturday's tournaments: Friday 6PM
 - Sunday's tournaments: Saturday 6PM
 </En>
+</Expand>
 
+<Expand>
 <Fi>
 ### Yhteystietojen kysyminen
 </Fi>
@@ -461,63 +485,78 @@ When signing up for a tournament via the Konsti app, the user is prompted to fil
 not shown to other Konsti users, only to Ropecon desk staff, who will pass on necessary
 contact information to tournament organizers.
 </En>
+</Expand>
 
 <Fi>
-## Työpajoihin ja muuhun ohjelmaan ilmoittautuminen
+## Työpajoihin ilmoittautuminen
 </Fi>
 
 <En>
-## Workshops and other program
+## Workshop sign-ups
 </En>
 
 <Fi>
-Uusina ohjelmatyyppeinä Konstista löytyy vuonna 2023 myös työpajoja ja yksittäisiä muita ohjelmanumeroita. Näihinkin on
-käytössä suorailmoittautuminen eli paikat täytetään ilmoittautumisjärjestyksessä.
+Työpajoihin ilmoittaudutaan suoraan eli paikat täytetään ilmoittautumisjärjestyksessä.
 </Fi>
 
 <En>
-In 2023, many workshops and some other program items are signed up to in Konsti. These
-also use direct sign-up, which means that places are filled in the order of sign-ups.
+Workshops use direct signup and seats are reserved in signup order.
+</En>
+
+<Expand>
+<Fi>
+### Työpajailmoittautumisten aikataulu
+</Fi>
+
+<En>
+### Workshop sign-up schedule
 </En>
 
 <Fi>
-### Työpajailmoittautumisten avautuminen
+- Työpajoihin ilmoittautuminen aukeaa neljä tuntia ennen työpajan alkua.
+- Paitsi jos työpaja alkaa ennen klo 12, niin ilmoittautuminen aukeaa edellisenä päivänä klo 18.
 </Fi>
 
 <En>
-### Sign-up period start times for workshops
+- Signup for the workshops opens four hours before the workshop begins.
+- Except if the workshop begins before 12 PM, then registration opens the previous day at 6 PM.
+</En>
+</Expand>
+
+<Fi>
+## Muuhun ohjelmaan ilmoittautuminen
+</Fi>
+
+<En>
+## Other program sign-ups
 </En>
 
 <Fi>
-- Perjantaina klo 15, jos työpaja on perjantaina
-- Perjantaina klo 18, jos työpaja on lauantaina alkaen viimeistään klo 14
-- Lauantaina klo 9, jos työpaja on lauantaina alkaen klo 14 jälkeen
-- Lauantaina klo 18, jos työpaja on sunnuntaina alkaen viimeistään klo 14
-- Sunnuntaina klo 9, jos työpaja on sunnuntaina alkaen klo 14 jälkeen
+Muuhun ohjelmaan ilmoittaudutaan suoraan eli paikat täytetään ilmoittautumisjärjestyksessä.
 </Fi>
 
 <En>
-- Workshops starting on Friday: Friday 3PM
-- Workshops starting on Saturday on or before 2PM: Friday 6PM
-- Workshops starting on Saturday after 2PM: Saturday 9AM
-- Workshops starting on Sunday on or before 2PM: Saturday: 6PM
-- Workshops starting on Sunday after 2PM: Sunday 9AM
+Other program items use direct signup and seats are reserved in signup order.
+</En>
+
+<Expand>
+<Fi>
+### Muun ohjelman ilmoittautumisten aikataulu
+</Fi>
+
+<En>
+### Other program sign-up schedule
 </En>
 
 <Fi>
-### Muun ohjelman ilmoittautumisten avautuminen
+- Muihin ohjelmanumeroihin ilmoittautuminen aukeaa neljä tuntia ennen työpajan alkua.
+- Paitsi jos ohjelmanumero alkaa ennen klo 12, niin ilmoittautuminen aukeaa edellisenä päivänä klo 18.
 </Fi>
 
 <En>
-### Sign-up period start time for other program
+- Signup for other program items opens four hours before the workshop begins.
+- Except if the program item begins before 12 PM, then registration opens the previous day at 6 PM.
 </En>
-
-<Fi>
-Kaikkien muiden Konstia käyttävien ohjelmanumeroiden ilmoittautuminen alkaa perjantaina klo 15.
-</Fi>
-
-<En>
-Sign-up for all other program items that use Konsti starts on Friday at 3PM.
-</En>
+</Expand>
 
 </Ropecon>

--- a/client/src/markdown/components/Expand.tsx
+++ b/client/src/markdown/components/Expand.tsx
@@ -1,0 +1,49 @@
+import { ReactElement, ReactNode, useState } from "react";
+import styled from "styled-components";
+import { useTranslation } from "react-i18next";
+import { partition } from "lodash-es";
+import { ExpandButton } from "client/components/ExpandButton";
+import { RaisedCard } from "client/components/RaisedCard";
+
+interface Props {
+  children: ReactNode;
+}
+
+// eslint-disable-next-line import/no-unused-modules
+export const Expand = ({ children }: Props): ReactElement | null => {
+  const { t, i18n } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+
+  if (!children || !Array.isArray(children)) {
+    return null;
+  }
+
+  const headerElements = ["h2", "h3"];
+
+  const [headers, elements] = partition(children, (child) =>
+    headerElements.includes(child.props.children.type as string),
+  );
+
+  const header = i18n.language === "fi" ? headers[0] : headers[1];
+  const headerText = header.props.children.props.children;
+
+  return (
+    <div>
+      <ExpandButton
+        isExpanded={isExpanded}
+        showMoreText={header}
+        showLessText={header}
+        showMoreAriaLabel={`${t("aboutView.showMore")} ${headerText}`}
+        showLessAriaLabel={`${t("aboutView.showLess")} ${headerText}`}
+        ariaControls={`more-info-${headerText}`}
+        onClick={() => setIsExpanded(!isExpanded)}
+      />
+
+      {isExpanded && <StyledRaisedCard>{elements}</StyledRaisedCard>}
+    </div>
+  );
+};
+
+const StyledRaisedCard = styled(RaisedCard)`
+  margin: 0;
+`;

--- a/client/src/markdown/components/Expand.tsx
+++ b/client/src/markdown/components/Expand.tsx
@@ -18,7 +18,7 @@ export const Expand = ({ children }: Props): ReactElement | null => {
     return null;
   }
 
-  const headerElements = ["h2", "h3"];
+  const headerElements = ["h2"];
 
   const [headers, elements] = partition(children, (child) =>
     headerElements.includes(child.props.children.type as string),


### PR DESCRIPTION
Add expand sections to about pages

![image](https://github.com/con2/konsti/assets/1327412/ab10c12d-8458-43c8-a44b-e7802b69531c)

![image](https://github.com/con2/konsti/assets/1327412/e86acedb-2eb4-4129-a6c0-cfbf5be98c1c)
