### PR TITLE
Disable enableRemoveOverlapSignups for Tracon 2024

### DIFF
--- a/server/src/features/assignment/runAssignment.ts
+++ b/server/src/features/assignment/runAssignment.ts
@@ -136,7 +136,7 @@ export const runAssignment = async ({
     return saveResultsResult;
   }
 
-  if (config.server().enableRemoveOverlapSignups) {
+  if (config.event().enableRemoveOverlapSignups) {
     logger.info("Remove overlapping signups");
     const removeOverlapSignupsResult = await removeOverlapSignups(
       assignResults.results,

--- a/server/src/test/setupTests.ts
+++ b/server/src/test/setupTests.ts
@@ -31,4 +31,5 @@ vi.spyOn(config, "event").mockReturnValue({
   eventStartTime: "2023-07-28T12:00:00Z", // Fri 15:00 GMT+3
   directSignupAlwaysOpenIds: ["1234"],
   twoPhaseSignupProgramTypes: [ProgramType.TABLETOP_RPG, ProgramType.LARP],
+  enableRemoveOverlapSignups: true,
 });

--- a/shared/config/eventConfig.ts
+++ b/shared/config/eventConfig.ts
@@ -24,6 +24,7 @@ export const eventConfig: EventConfig = {
   signupOpen: true,
   resultsVisible: true,
   logInvalidStartTimes: false,
+  enableRemoveOverlapSignups: false,
 
   activeProgramTypes: [
     ProgramType.TABLETOP_RPG,

--- a/shared/config/eventConfigTypes.ts
+++ b/shared/config/eventConfigTypes.ts
@@ -74,4 +74,5 @@ export interface EventConfig {
   directSignupOpenToEndProgramTypes: ProgramType[];
   activeProgramTypes: ProgramType[];
   popularityAlgorithm: AssignmentAlgorithm.RANDOM | AssignmentAlgorithm.PADG;
+  enableRemoveOverlapSignups: boolean;
 }

--- a/shared/config/serverConfig.ts
+++ b/shared/config/serverConfig.ts
@@ -18,7 +18,6 @@ export interface ServerConfig {
   bundleCompression: boolean;
   autoUpdateProgramEnabled: boolean;
   programUpdateInterval: string;
-  enableRemoveOverlapSignups: boolean;
   updateProgramItemPopularityEnabled: boolean;
   useLocalProgramFile: boolean;
   autoAssignAttendeesEnabled: boolean;
@@ -58,7 +57,6 @@ const commonConfig = {
 
   // App settings
   bundleCompression: true,
-  enableRemoveOverlapSignups: true,
 
   // Default DB values
   defaultSignupStrategy: EventSignupStrategy.LOTTERY_AND_DIRECT,


### PR DESCRIPTION
Disable `enableRemoveOverlapSignups` for Tracon 2024