### PR TITLE
Make notification message shorter so it fits on one line on mobile

### DIFF
--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -5,7 +5,7 @@ export const translationEN = {
   logoAltText: "Konsti",
   announcement: "Sign-up has ended. Results will be released soon.",
   appUpdateBanner: {
-    message: "Konsti has been updated. Please reload the page.",
+    message: "Konsti has been updated.",
     reload: "Reload",
   },
   testTime: {

--- a/client/src/locales/fi.ts
+++ b/client/src/locales/fi.ts
@@ -4,7 +4,7 @@ export const translationFI = {
   logoAltText: "Konsti",
   announcement: "Ilmoittautuminen on päättynyt. Tulokset julkaistaan piakkoin.",
   appUpdateBanner: {
-    message: "Konsti on päivitetty. Ole hyvä ja lataa sivu uudelleen.",
+    message: "Konsti on päivitetty.",
     reload: "Lataa uudelleen",
   },
   testTime: {


### PR DESCRIPTION
Make notification message shorter so it fits on one line on mobile

<img width="395" height="110" alt="image" src="https://github.com/user-attachments/assets/e50e6310-3f70-457b-8194-28d722e35ccf" />
